### PR TITLE
Fix hanging transport layer shutdown in tests

### DIFF
--- a/pkg/deploytest/deployment.go
+++ b/pkg/deploytest/deployment.go
@@ -115,7 +115,11 @@ func NewDeployment(testConfig *TestConfig) (*Deployment, error) {
 		case "fake":
 			transport = fakeTransport.Link(t.NewNodeIDFromInt(i))
 		case "grpc":
-			transport = localGrpcTransport(membership, t.NewNodeIDFromInt(i))
+			transport = localGrpcTransport(
+				membership,
+				t.NewNodeIDFromInt(i),
+				logging.Decorate(config.Logger, "gRPC: "),
+			)
 		}
 
 		// Create instance of test replica.
@@ -221,7 +225,7 @@ func (d *Deployment) Run(ctx context.Context, tickInterval time.Duration) []Node
 // localGrpcTransport creates an instance of GrpcTransport based on the numeric IDs of test replicas.
 // It is assumed that node ID strings must be parseable to decimal numbers.
 // The network address of each test replica is the loopback 127.0.0.1.
-func localGrpcTransport(nodeIds []t.NodeID, ownId t.NodeID) *grpctransport.GrpcTransport {
+func localGrpcTransport(nodeIds []t.NodeID, ownId t.NodeID, logger logging.Logger) *grpctransport.GrpcTransport {
 
 	// Compute network addresses and ports for all test replicas.
 	// Each test replica is on the local machine - 127.0.0.1
@@ -233,7 +237,7 @@ func localGrpcTransport(nodeIds []t.NodeID, ownId t.NodeID) *grpctransport.GrpcT
 	return grpctransport.NewGrpcTransport(
 		membership,
 		ownId,
-		logging.Decorate(logging.ConsoleInfoLogger, "gRPC: ", "node", ownId),
+		logger,
 	)
 }
 

--- a/pkg/deploytest/testreplica.go
+++ b/pkg/deploytest/testreplica.go
@@ -165,12 +165,12 @@ func (tr *TestReplica) Run(ctx context.Context, tickInterval time.Duration) Node
 	case *grpctransport.GrpcTransport:
 		err := transport.Start()
 		Expect(err).NotTo(HaveOccurred())
-		transport.Connect()
+		transport.Connect(ctx)
 	}
 
 	// Run the node until it stops and obtain the node's final status.
 	exitErr := node.Run(ctx, ticker.C)
-	fmt.Println("Node run returned!")
+	tr.Config.Logger.Log(logging.LevelDebug, "Node run returned!")
 
 	finalStatus, statusErr := node.Status(context.Background())
 
@@ -180,15 +180,15 @@ func (tr *TestReplica) Run(ctx context.Context, tickInterval time.Duration) Node
 
 	// Wait for the local request submission thread.
 	wg.Wait()
-	fmt.Println("Fake request submission done.")
+	tr.Config.Logger.Log(logging.LevelInfo, "Fake request submission done.")
 
 	// ATTENTION! This is hacky!
 	// If the test replica used the GRPC transport, stop the Net module.
 	switch transport := tr.Net.(type) {
 	case *grpctransport.GrpcTransport:
-		fmt.Println("Stopping gRPC transport.")
+		tr.Config.Logger.Log(logging.LevelDebug, "Stopping gRPC transport.")
 		transport.Stop()
-		fmt.Println("gRPC transport stopped.")
+		tr.Config.Logger.Log(logging.LevelDebug, "gRPC transport stopped.")
 	}
 
 	// Return the final node status.


### PR DESCRIPTION
The transport layer is writing messages that it receives over the
network to a channel, from which the node implementation reads them.
When the node is shutting down, it stops reading incoming messages from
this channel. However, if there are still incoming messages on the wire
at that time, the transport layer tries to write them to the channel and
blocks (since nobody reads any more). This prevented a clean shutdown of
the transport layer.

Now the connecting node explicitly cancels the context of the connection
when disconnecting and the node being connected uses a select statement,
waiting for this event alongside trying to write the message to the
processing channel.

Fixes #36 