### PR TITLE
ISS: Fix quorum sizes for any n > 3f

### DIFF
--- a/pkg/iss/iss.go
+++ b/pkg/iss/iss.go
@@ -1070,8 +1070,21 @@ func serializeLogEntryForHashing(entry *CommitLogEntry) [][]byte {
 	return data
 }
 
+func maxFaulty(n int) int {
+	// assuming n > 3f:
+	//   return max f
+	return (n - 1) / 3
+}
+
 func strongQuorum(n int) int {
-	// assuming n = 3f + 1:
-	//     2 *  f    + 1
-	return 2*(n-1)/3 + 1
+	// assuming n > 3f:
+	//   return min q: 2q > n+f
+	f := maxFaulty(n)
+	return (n+f)/2 + 1
+}
+
+func weakQuorum(n int) int {
+	// assuming n > 3f:
+	//   return min q: q > f
+	return maxFaulty(n) + 1
 }


### PR DESCRIPTION
The total number of replicas does not have to be exactly 3f+1 for some
natural number f. Fix the helper functions to calculate strong and
weak Byzantine quorums such that they give correct result in any case.