### PR TITLE
ISS: Clean up delivered commit log entries

### DIFF
--- a/pkg/iss/iss.go
+++ b/pkg/iss/iss.go
@@ -886,6 +886,11 @@ func (iss *ISS) processCommitted() *events.EventList {
 		iss.logger.Log(logging.LevelDebug, "Delivering entry.",
 			"sn", iss.nextDeliveredSN, "nReq", len(iss.commitLog[iss.nextDeliveredSN].Batch.Requests))
 
+		// Remove just delivered batch from the temporary
+		// store of batches that were agreed upon out-of-order.
+		delete(iss.commitLog, iss.nextDeliveredSN)
+
+		// Increment the sequence number of the next batch to deliver.
 		iss.nextDeliveredSN++
 	}
 


### PR DESCRIPTION
This pull request fixes a memory leak in the ISS state.