### PR TITLE
Use Context instead of ExitC in Node workers

### DIFF
--- a/node.go
+++ b/node.go
@@ -269,7 +269,7 @@ func (n *Node) process(ctx context.Context, tickC <-chan time.Time) error {
 		wg.Add(1)
 		go func(work workFunc) {
 			defer wg.Done()
-			n.doUntilErr(work)
+			n.doUntilErr(ctx, work)
 		}(work)
 	}
 


### PR DESCRIPTION
This approach is more idiomatic and thus easier to read and understand.

Signed-off-by: Matej Pavlovic <matopavlovic@gmail.com>