### PR TITLE
Fix transitioning into new epoch

### DIFF
--- a/pkg/iss/config.go
+++ b/pkg/iss/config.go
@@ -8,6 +8,7 @@ package iss
 
 import (
 	"fmt"
+
 	t "github.com/filecoin-project/mir/pkg/types"
 )
 
@@ -160,7 +161,7 @@ func CheckConfig(c *Config) error {
 func DefaultConfig(membership []t.NodeID) *Config {
 	return &Config{
 		Membership:                   membership,
-		SegmentLength:                8,
+		SegmentLength:                4,
 		MaxBatchSize:                 4,
 		MaxProposeDelay:              16,
 		NumBuckets:                   len(membership),


### PR DESCRIPTION
This pull request fixes a bug introduced in c01d2e8 which broke `ISS.epochFinished` and resolves #2. It also adjusts the default ISS configuration such that there is at least one integration test that has to order requests across multiple epochs.