### PR TITLE
Add LGTM badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/filecoin-project/mir.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/filecoin-project/mir/alerts/)
+
 # Mir - The Distributed Protocol Implementation Framework
 
 Mir is a framework for implementing, debugging, and analyzing distributed protocols.


### PR DESCRIPTION
This PR adds a badge on the top of README file that shows the number of alerts detected by [LGTM analysis](https://lgtm.com/help/lgtm/about-lgtm). 