### PR TITLE
Replace LGTM with GitHub Code Scanning

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,43 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '43 11 * * 6'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/filecoin-project/mir.svg)](https://pkg.go.dev/github.com/filecoin-project/mir)
 [![Mir Test](https://github.com/filecoin-project/mir/actions/workflows/test.yml/badge.svg)](https://github.com/filecoin-project/mir/actions/workflows/test.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/filecoin-project/mir)](https://goreportcard.com/report/github.com/filecoin-project/mir)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/filecoin-project/mir.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/filecoin-project/mir/alerts/)
 
 # Mir - The Distributed Protocol Implementation Framework
 

--- a/pkg/crypto/pseudo.go
+++ b/pkg/crypto/pseudo.go
@@ -29,7 +29,7 @@ var (
 func NodePseudo(nodes []t.NodeID, clients []t.ClientID, ownID t.NodeID, seed int64) (*Crypto, error) { //nolint:dupl
 
 	// Create a new pseudorandom source from the given seed.
-	randomness := prand.New(prand.NewSource(seed)) //nolint:gosec // lgtm[go/insecure-randomness]
+	randomness := prand.New(prand.NewSource(seed)) //nolint:gosec
 
 	// Generate node keys.
 	// All private keys except the own one will be discarded.
@@ -79,7 +79,7 @@ func NodePseudo(nodes []t.NodeID, clients []t.ClientID, ownID t.NodeID, seed int
 func ClientPseudo(nodes []t.NodeID, clients []t.ClientID, ownID t.ClientID, seed int64) (*Crypto, error) { //nolint:dupl
 
 	// Create a new pseudorandom source from the given seed.
-	randomness := prand.New(prand.NewSource(seed)) //nolint:gosec // lgtm[go/insecure-randomness]
+	randomness := prand.New(prand.NewSource(seed)) //nolint:gosec
 
 	// Generate node keys.
 	// All node private keys are discarded.

--- a/pkg/iss/config.go
+++ b/pkg/iss/config.go
@@ -122,7 +122,7 @@ func CheckConfig(c *Config) error {
 
 	// MaxBatchSize must not be negative (it can be zero though, signifying infinite batch size).
 	// This check is technically not necessary for an unsigned type, but we keep it in case the type changes one day.
-	if c.MaxBatchSize < 0 { // nolint // lgtm[go/negative-length-check]
+	if c.MaxBatchSize < 0 { //nolint:staticcheck
 		return fmt.Errorf("negative MaxBatchSize: %d", c.MaxBatchSize)
 	}
 


### PR DESCRIPTION
GitHub Code Scanning [can use the same mechanism as LGTM.com](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-with-codeql). Switch into using GitHub Code Scanning.