### PR TITLE
Do not exit debugger immediately after last event

### DIFF
--- a/cmd/mircat/debug.go
+++ b/cmd/mircat/debug.go
@@ -99,7 +99,8 @@ func debug(args *arguments) error {
 		return fmt.Errorf("error reading event log: %w", err)
 	}
 
-	fmt.Println("End of trace, done debugging.")
+	fmt.Println("End of trace, done debugging. Press Enter to exit.")
+	bufio.NewScanner(os.Stdin).Scan()
 
 	return nil
 }


### PR DESCRIPTION
After submitting the last event to the node when debugging,
the debugger stopped immediately, not giving the node a chance
for actually applying it. This is fixed now.

Signed-off-by: Matej Pavlovic <matopavlovic@gmail.com>