### PR TITLE
Keep resending critical messages in ISS

### DIFF
--- a/pkg/iss/config.go
+++ b/pkg/iss/config.go
@@ -95,6 +95,9 @@ type Config struct {
 	// and, if so, sends them the latest state.
 	CatchUpTimerPeriod time.Duration
 
+	// Time interval for repeated retransmission of checkpoint messages.
+	CheckpointResendPeriod time.Duration
+
 	// View change timeout for the PBFT sub-protocol, in ticks.
 	// TODO: Separate this in a sub-group of the ISS config, maybe even use a field of type PBFTConfig in Config.
 	PBFTDoneResendPeriod         time.Duration
@@ -194,6 +197,7 @@ func DefaultConfig(membership []t.NodeID) *Config {
 		CatchUpTimerPeriod:           maxProposeDelay, // maxProposeDelay is picked quite arbitrarily, could be anything
 		PBFTDoneResendPeriod:         maxProposeDelay,
 		PBFTCatchUpDelay:             maxProposeDelay, // maxProposeDelay is picked quite arbitrarily, could be anything
+		CheckpointResendPeriod:       maxProposeDelay, // maxProposeDelay is picked quite arbitrarily, could be anything
 		PBFTViewChangeBatchTimeout:   4 * maxProposeDelay,
 		PBFTViewChangeSegmentTimeout: 2 * time.Duration(segmentLength) * maxProposeDelay,
 		PBFTViewChangeResendPeriod:   maxProposeDelay, // maxProposeDelay is picked quite arbitrarily, could be anything

--- a/pkg/iss/iss.go
+++ b/pkg/iss/iss.go
@@ -784,8 +784,13 @@ func (iss *ISS) initEpoch(newEpoch t.EpochNr) {
 	epoch := &epochInfo{
 		Nr:         newEpoch,
 		Membership: iss.config.Membership, // TODO: Make a proper copy once reconfiguration is supported.
-		Checkpoint: newCheckpointTracker(iss.ownID, iss.nextDeliveredSN, newEpoch,
-			logging.Decorate(iss.logger, "CT: ", "epoch", newEpoch)),
+		Checkpoint: newCheckpointTracker(
+			iss.ownID,
+			iss.nextDeliveredSN,
+			newEpoch,
+			t.TimeDuration(iss.config.CheckpointResendPeriod),
+			logging.Decorate(iss.logger, "CT: ", "epoch", newEpoch),
+		),
 	}
 	iss.epochs[newEpoch] = epoch
 	iss.epoch = epoch

--- a/pkg/iss/pbftgoodcase.go
+++ b/pkg/iss/pbftgoodcase.go
@@ -134,6 +134,8 @@ func (pbft *pbftInstance) propose(batch *requestpb.Batch) *events.EventList {
 	preprepare := pbftPreprepareMsg(sn, pbft.view, batch, false)
 
 	// Create a Preprepare message send Event.
+	// No need for periodic re-transmission.
+	// In the worst case, dropping of these messages may result in a view change, but will not compromise correctness.
 	msgSendEvent := pbft.eventService.SendMessage(
 		PbftPreprepareSBMessage(preprepare),
 		pbft.segment.Membership,
@@ -234,7 +236,9 @@ func (pbft *pbftInstance) sendPrepare(prepare *isspbftpb.Prepare) *events.EventL
 	// Create persist event.
 	persistEvent := pbft.eventService.WALAppend(PbftPersistPrepare(prepare))
 
-	// Append send event as a follow-up
+	// Append send event as a follow-up.
+	// No need for periodic re-transmission.
+	// In the worst case, dropping of these messages may result in a view change, but will not compromise correctness.
 	persistEvent.FollowUp(pbft.eventService.SendMessage(
 		PbftPrepareSBMessage(prepare),
 		pbft.segment.Membership,
@@ -279,7 +283,9 @@ func (pbft *pbftInstance) sendCommit(commit *isspbftpb.Commit) *events.EventList
 	// Create persist event.
 	persistEvent := pbft.eventService.WALAppend(PbftPersistCommit(commit))
 
-	// Append send event as a follow-up
+	// Append send event as a follow-up.
+	// No need for periodic re-transmission.
+	// In the worst case, dropping of these messages may result in a view change, but will not compromise correctness.
 	persistEvent.FollowUp(pbft.eventService.SendMessage(
 		PbftCommitSBMessage(commit),
 		pbft.segment.Membership,

--- a/pkg/iss/pbftsegmentchkp.go
+++ b/pkg/iss/pbftsegmentchkp.go
@@ -224,6 +224,7 @@ func (pbft *pbftInstance) applyMsgCatchUpRequest(
 	if preprepare := pbft.lookUpPreprepare(t.SeqNr(catchUpReq.Sn), catchUpReq.Digest); preprepare != nil {
 
 		// If the requested Preprepare message is available, send it to the originator of the request.
+		// No need for periodic re-transmission. The requester will re-transmit the request if needed.
 		return events.ListOf(pbft.eventService.SendMessage(PbftCatchUpResponseSBMessage(preprepare), []t.NodeID{from}))
 	}
 

--- a/pkg/iss/pbftviewchangestate.go
+++ b/pkg/iss/pbftviewchangestate.go
@@ -146,9 +146,15 @@ func (vcState *pbftViewChangeState) SetLocalPreprepares(pbft *pbftInstance, view
 	}
 }
 
+// askForMissingPreprepares requests the Preprepare messages that are part of a new view.
+// The new primary might have received a prepare certificate from other nodes in the ViewChange messages they sent
+// and thus the new primary has to re-propose the corresponding batch by including the corresponding Preprepare message
+// the NewView message. However, the new primary might not have all the corresponding Preprepare messages,
+// in which case it calls this function.
+// Note that the requests for missing Preprepare messages need not necessarily be periodically re-transmitted.
+// If they are dropped, the new primary will simply never send a NewView message
+// and will be succeeded by another primary after another view change.
 func (vcState *pbftViewChangeState) askForMissingPreprepares(eventService *sbEventService) *events.EventList {
-
-	// TODO: Do this periodically, not just once. Messages might get lost!
 
 	eventsOut := events.EmptyList()
 	for sn, digest := range vcState.reproposals {


### PR DESCRIPTION
The only one that was still missing was the checkpoint message.
The rest is either not critical for correctness or already being re-transmitted.

This is just the minimal modification to guarantee correctness of the protocol. Even some non-critical protocol messages might be periodically re-transmitted to avoid view changes in certain cases, but that is future work for another PR.