### PR TITLE
Increase the timeout for linter in CI

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,9 @@ linters:
     - gofmt
     - misspell
 
+run:
+  timeout: 2m
+
 issues:
   exclude-rules:
     - path: .*\.pb\.mir\.go


### PR DESCRIPTION
For some reason, the linter works fine within the timeout in PRs, but not in the main branch. Will try to increase the timeout to fix CI builds in main.