### PR TITLE
Fix semgrep linting errors

### DIFF
--- a/pkg/crypto/defaultimpl.go
+++ b/pkg/crypto/defaultimpl.go
@@ -18,7 +18,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	t "github.com/filecoin-project/mir/pkg/types"
@@ -232,7 +232,7 @@ func SerializePrivKey(privKey interface{}) (privKeyBytes []byte, err error) {
 func PubKeyFromFile(fileName string) ([]byte, error) {
 
 	// Read contents of the file.
-	certBytes, err := ioutil.ReadFile(fileName)
+	certBytes, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +278,7 @@ func PubKeyFromFile(fileName string) ([]byte, error) {
 func PrivKeyFromFile(file string) ([]byte, error) {
 
 	// Read contents of the file.
-	fileData, err := ioutil.ReadFile(file)
+	fileData, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/net/libp2p/libp2ptransport.go
+++ b/pkg/net/libp2p/libp2ptransport.go
@@ -151,10 +151,15 @@ func (t *Transport) openStream(ctx context.Context, p peer.ID) (network.Stream, 
 
 		t.logger.Log(logging.LevelError, fmt.Sprintf("failed to open stream: %v", err))
 
+		delay := time.NewTimer(defaultMaxTimeout)
+
 		select {
-		case <-time.After(defaultMaxTimeout):
+		case <-delay.C:
 			continue
 		case <-ctx.Done():
+			if !delay.Stop() {
+				<-delay.C
+			}
 			return nil, fmt.Errorf("context closed")
 		}
 	}
@@ -194,7 +199,7 @@ func (t *Transport) Send(dest types.NodeID, payload *messagepb.Message) error {
 		return err
 	}
 
-	return err
+	return nil
 }
 
 func (t *Transport) mirHandler(s network.Stream) {


### PR DESCRIPTION
This PR fixes several bugs found by `semgrep` run with the following commands:
- `semgrep --config "p/semgrep-go-correctness" ./`
- `semgrep --config "p/trailofbits" ./`