### PR TITLE
Add Stop method to Node

### DIFF
--- a/samples/chat-demo/main.go
+++ b/samples/chat-demo/main.go
@@ -281,7 +281,7 @@ func run() error {
 	if args.Verbose {
 		fmt.Println("Stopping server.")
 	}
-	ctx.Done()
+	node.Stop()
 	wg.Wait()
 
 	return nodeErr


### PR DESCRIPTION
This adds a cleaner way of stopping the node, so one does not have to cancel the context given to the Run method.