### PR TITLE
Enable new linters and fix found bugs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,11 +16,25 @@ linters:
     - exportloopref
     - revive
     - dupl
+    - gosimple
+    - gocognit
+    - unused
+    - stylecheck
+    - ineffassign
+    - unconvert
+    - varcheck
+    - errorlint
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/filecoin-project/mir
+  gocognit:
+    min-complexity: 50
 
 run:
-  timeout: 2m
+  timeout: 5m
 
 issues:
   exclude-rules:
     - path: .*\.pb\.mir\.go
-      linters: [revive, golint]
+      linters: [revive, stylecheck]

--- a/cmd/mircat/debug.go
+++ b/cmd/mircat/debug.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -96,7 +97,7 @@ func debug(args *arguments) error {
 		}
 	}
 
-	if err != io.EOF {
+	if errors.Is(err, io.EOF) {
 		return fmt.Errorf("error reading event log: %w", err)
 	}
 

--- a/cmd/mircat/display.go
+++ b/cmd/mircat/display.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -57,7 +58,7 @@ func displayEvents(args *arguments) error {
 		}
 	}
 
-	if err != io.EOF {
+	if errors.Is(err, io.EOF) {
 		return fmt.Errorf("error reading event log: %w", err)
 	}
 

--- a/cmd/mircat/eventloader.go
+++ b/cmd/mircat/eventloader.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -54,7 +55,7 @@ func getEventList(file *os.File) (map[string]struct{}, map[string]struct{}, int,
 			}
 		}
 	}
-	if err != io.EOF {
+	if errors.Is(err, io.EOF) {
 		return events, issEvents, cnt, fmt.Errorf("failed reading event log: %w", err)
 	}
 
@@ -64,15 +65,15 @@ func getEventList(file *os.File) (map[string]struct{}, map[string]struct{}, int,
 // eventName returns a string name of an Event.
 func eventName(event *eventpb.Event) string {
 	return strings.ReplaceAll(
-		reflect.TypeOf(event.Type).Elem().Name(), //gets the type's name i.e. Event_Tick , Event_Iss,etc
+		reflect.TypeOf(event.Type).Elem().Name(), // gets the type's name i.e. Event_Tick , Event_Iss,etc
 		"Event_", "")
 }
 
 // issEventName returns a string name of an ISS event.
 func issEventName(issEvent *isspb.ISSEvent) string {
 	return strings.ReplaceAll(
-		reflect.TypeOf(issEvent.Type).Elem().Name(), //gets the type's name i.e. ISSEvent_sb , ISSEvent_PersistCheckpoint,etc
-		"ISSEvent_", "") //replaces the given substring from the name
+		reflect.TypeOf(issEvent.Type).Elem().Name(), // gets the type's name i.e. ISSEvent_sb , ISSEvent_PersistCheckpoint,etc
+		"ISSEvent_", "") // replaces the given substring from the name
 }
 
 // selected returns true if the given event has been selected by the user according to the given criteria.

--- a/pkg/crypto/ecdsa.go
+++ b/pkg/crypto/ecdsa.go
@@ -32,7 +32,7 @@ func ecdsaSignatureFromBytes(raw []byte) (*big.Int, *big.Int, error) {
 	sig := new(ecdsaSignature)
 	_, err := asn1.Unmarshal(raw, sig)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed unmashalling signature [%s]", err)
+		return nil, nil, fmt.Errorf("failed unmashalling signature [%w]", err)
 	}
 
 	// Validate sig

--- a/pkg/deploytest/testreplica.go
+++ b/pkg/deploytest/testreplica.go
@@ -8,13 +8,12 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/filecoin-project/mir/pkg/net"
-
 	"github.com/filecoin-project/mir"
 	"github.com/filecoin-project/mir/pkg/eventlog"
 	"github.com/filecoin-project/mir/pkg/events"
 	"github.com/filecoin-project/mir/pkg/logging"
 	"github.com/filecoin-project/mir/pkg/modules"
+	"github.com/filecoin-project/mir/pkg/net"
 	"github.com/filecoin-project/mir/pkg/pb/requestpb"
 	"github.com/filecoin-project/mir/pkg/requestreceiver"
 	"github.com/filecoin-project/mir/pkg/simplewal"

--- a/pkg/eventlog/interceptor.go
+++ b/pkg/eventlog/interceptor.go
@@ -180,7 +180,7 @@ func (i *Recorder) Stop() error {
 	<-i.exitC
 	i.exitErrMutex.Lock()
 	defer i.exitErrMutex.Unlock()
-	if i.exitErr == errStopped {
+	if errors.Is(i.exitErr, errStopped) {
 		return nil
 	}
 	return i.exitErr
@@ -285,7 +285,7 @@ func NewReader(source io.Reader) (*Reader, error) {
 func (r *Reader) ReadEntry() (*recordingpb.Entry, error) {
 	re := &recordingpb.Entry{}
 	err := readSizePrefixedProto(r.source, re, r.buffer)
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		r.gzReader.Close()
 		return re, err
 	}
@@ -300,7 +300,7 @@ func (r *Reader) ReadEntry() (*recordingpb.Entry, error) {
 func readSizePrefixedProto(reader *bufio.Reader, msg proto.Message, buffer *bytes.Buffer) error {
 	l, err := binary.ReadVarint(reader)
 	if err != nil {
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return err
 		}
 		return errors.WithMessage(err, "could not read size prefix")

--- a/pkg/iss/iss.go
+++ b/pkg/iss/iss.go
@@ -17,6 +17,8 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/filecoin-project/mir/pkg/events"
 	"github.com/filecoin-project/mir/pkg/logging"
 	"github.com/filecoin-project/mir/pkg/messagebuffer"
@@ -28,7 +30,6 @@ import (
 	"github.com/filecoin-project/mir/pkg/serializing"
 	t "github.com/filecoin-project/mir/pkg/types"
 	"github.com/filecoin-project/mir/pkg/util/maputil"
-	"google.golang.org/protobuf/proto"
 )
 
 // ============================================================

--- a/pkg/modules/mockmodules/mock_modules.go
+++ b/pkg/modules/mockmodules/mock_modules.go
@@ -1,10 +1,11 @@
 package mockmodules
 
 import (
+	"github.com/golang/mock/gomock"
+
 	"github.com/filecoin-project/mir/pkg/events"
 	"github.com/filecoin-project/mir/pkg/modules"
 	"github.com/filecoin-project/mir/pkg/modules/mockmodules/internal/mock_internal"
-	"github.com/golang/mock/gomock"
 )
 
 // MockPassiveModule is a slightly more user-friendly wrapper around gomock_modules.MockPassiveModule.

--- a/pkg/pb/eventpb/eventpb.pb.mir.go
+++ b/pkg/pb/eventpb/eventpb.pb.mir.go
@@ -1,11 +1,12 @@
 package eventpb
 
 import (
-	availabilitypb "github.com/filecoin-project/mir/pkg/pb/availabilitypb"
-	bcbpb "github.com/filecoin-project/mir/pkg/pb/bcbpb"
-	isspb "github.com/filecoin-project/mir/pkg/pb/isspb"
-	mempoolpb "github.com/filecoin-project/mir/pkg/pb/mempoolpb"
-	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/filecoin-project/mir/pkg/pb/availabilitypb"
+	"github.com/filecoin-project/mir/pkg/pb/bcbpb"
+	"github.com/filecoin-project/mir/pkg/pb/isspb"
+	"github.com/filecoin-project/mir/pkg/pb/mempoolpb"
 )
 
 type Event_Type = isEvent_Type

--- a/samples/chat-demo/main.go
+++ b/samples/chat-demo/main.go
@@ -22,6 +22,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/multiformats/go-multiaddr"
+	"gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/filecoin-project/mir"
 	mirCrypto "github.com/filecoin-project/mir/pkg/crypto"
 	"github.com/filecoin-project/mir/pkg/dummyclient"
@@ -34,8 +37,6 @@ import (
 	"github.com/filecoin-project/mir/pkg/requestreceiver"
 	t "github.com/filecoin-project/mir/pkg/types"
 	libp2ptools "github.com/filecoin-project/mir/pkg/util/libp2p"
-	"github.com/multiformats/go-multiaddr"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 const (


### PR DESCRIPTION
This PR enables several new linters, adds a setting for `goimport` linter to enforce the order of the project's packages, and also fixes the found bugs by the introduced linters.