### PR TITLE
Collect F+1 instead of (N+F)/2+1 signatures in multisigcollector

### DIFF
--- a/pkg/availability/multisigcollector/internal/common/common.go
+++ b/pkg/availability/multisigcollector/internal/common/common.go
@@ -37,16 +37,7 @@ func DefaultModuleConfig() *ModuleConfig {
 type ModuleParams struct {
 	InstanceUID []byte     // unique identifier for this instance of BCB, used to prevent cross-instance replay attacks
 	AllNodes    []t.NodeID // the list of participating nodes
-}
-
-// N is the total number of replicas.
-func (params *ModuleParams) N() int {
-	return len(params.AllNodes)
-}
-
-// F is the maximum number of replicas that can be tolerated.
-func (params *ModuleParams) F() int {
-	return (params.N() - 1) / 3
+	F           int        // the maximum number of failures tolerated. Must be less than (len(AllNodes)-1) / 2
 }
 
 // State represents the common state used by all parts of the multisig collector implementation.

--- a/pkg/availability/multisigcollector/internal/parts/certcreation/certcreation.go
+++ b/pkg/availability/multisigcollector/internal/parts/certcreation/certcreation.go
@@ -113,12 +113,12 @@ func IncludeCreatingCertificates(
 		return nil
 	})
 
-	// When a quorum (more than (N+F)/2) of signatures are collected, create and output a certificate.
+	// When F+1 signatures are collected, create and output a certificate.
 	dsl.UponCondition(m, func() error {
 		// Iterate over active outgoing requests.
 		//Most of the time, there is expected to be at most one active outgoing request.
 		for reqID, requestState := range state.RequestState {
-			if len(requestState.sigs) > (params.N()+params.F())/2 {
+			if len(requestState.sigs) > params.F+1 {
 				certNodes, certSigs := maputil.GetKeysAndValues(requestState.sigs)
 
 				requestingModule := t.ModuleID(requestState.ReqOrigin.Module)

--- a/pkg/availability/multisigcollector/internal/parts/certverification/certverification.go
+++ b/pkg/availability/multisigcollector/internal/parts/certverification/certverification.go
@@ -67,7 +67,7 @@ func verifyCertificateStructure(params *common.ModuleParams, cert *apb.Cert) (*m
 	mscCert := mscCertWrapper.Msc
 
 	// Check that the certificate contains a sufficient number of signatures.
-	if len(mscCert.Signers) <= (params.N()+params.F())/2 {
+	if len(mscCert.Signers) <= params.F+1 {
 		return nil, fmt.Errorf("insuficient number of signatures")
 	}
 


### PR DESCRIPTION
It is sufficient to store the data on F+1 nodes in order for it to be retrievable.