### PR TITLE
Fix transaction counting bug in simple mempool

### DIFF
--- a/pkg/mempool/simplemempool/internal/parts/formbatches/formbatches.go
+++ b/pkg/mempool/simplemempool/internal/parts/formbatches/formbatches.go
@@ -44,23 +44,22 @@ func IncludeBatchCreation(
 		var txs []*requestpb.Request
 		batchSize := 0
 
-		var i int
-		var txID t.TxID
-
-		for i, txID = range state.NewTxIDs {
+		txCount := 0
+		for _, txID := range state.NewTxIDs {
 			tx := state.TxByID[txID]
 
 			// TODO: add other limitations (if any) here.
-			if i == params.MaxTransactionsInBatch {
+			if txCount == params.MaxTransactionsInBatch {
 				break
 			}
 
 			txIDs = append(txIDs, txID)
 			txs = append(txs, tx)
 			batchSize += len(tx.Data)
+			txCount++
 		}
 
-		state.NewTxIDs = state.NewTxIDs[i:]
+		state.NewTxIDs = state.NewTxIDs[txCount:]
 
 		// Note that a batch may be empty.
 		mpdsl.NewBatch(m, t.ModuleID(origin.Module), txIDs, txs, origin)


### PR DESCRIPTION
The current implementation didn't properly count the number of transactions added to the batch.
When there was only one transaction in the mempool, the counter `i` would always keep the value 0 and `newTxIDs` was not trimmed properly.