### PR TITLE
Add hierarchical module IDs

### DIFF
--- a/pkg/types/moduleid.go
+++ b/pkg/types/moduleid.go
@@ -1,0 +1,40 @@
+package types
+
+import "strings"
+
+const Separator = "/"
+
+// TODO: Mention in the documentation that the Separator is a special sequence
+//       that must not be contained in a module ID.
+//       Technically, the only constraint is that no two modules whose IDs share the same prefix
+//       up to the first separator can coexist in a Node.
+//       However, we might still want to reserve the separator for future, more elaborate,
+//       native support for structured modules.
+
+// ModuleID represents an identifier of a module.
+// The intention is for it to correspond to a path in the module hierarchy.
+// However, technically, the Mir Node only cares for the ID's prefix up to the first separator and ignores the rest.
+// The rest of the ID can be used for any module-specific purposes.
+type ModuleID string
+
+// Pb converts a ModuleID to a type used in a Protobuf message.
+func (mid ModuleID) Pb() string {
+	return string(mid)
+}
+
+// Top returns the ID of the top-level module of the path, stripped of the IDs of the submodules.
+func (mid ModuleID) Top() ModuleID {
+	top, _, _ := strings.Cut(string(mid), Separator)
+	return ModuleID(top)
+}
+
+// Sub returns the identifier of a submodule within the top-level module, stripped of the top-level module identifier.
+func (mid ModuleID) Sub() ModuleID {
+	_, sub, _ := strings.Cut(string(mid), Separator)
+	return ModuleID(sub)
+}
+
+// Then combines the module ID with a relative path to its submodule in a single module ID.
+func (mid ModuleID) Then(submodule ModuleID) ModuleID {
+	return ModuleID(string(mid) + Separator + string(submodule))
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -306,17 +306,6 @@ func (td TimeDuration) Pb() uint64 {
 }
 
 // ================================================================================
-
-// ModuleID represents an identifier of a module.
-// Modules are stored under their identifiers in modules.Modules
-type ModuleID string
-
-// Pb converts a ModuleID to a type used in a Protobuf message.
-func (mid ModuleID) Pb() string {
-	return string(mid)
-}
-
-// ================================================================================
 // Auxiliary functions
 // ================================================================================
 

--- a/workitems.go
+++ b/workitems.go
@@ -34,7 +34,7 @@ func (wi workItems) AddEvents(events *events.EventList) error {
 	for event := iter.Next(); event != nil; event = iter.Next() {
 
 		// Look up the corresponding module's buffer and add the event to it.
-		if buffer, ok := wi[t.ModuleID(event.DestModule)]; ok {
+		if buffer, ok := wi[t.ModuleID(event.DestModule).Top()]; ok {
 			buffer.PushBack(event)
 		} else {
 			return fmt.Errorf("no buffer for module %v (adding event of type %T)", event.DestModule, event.Type)


### PR DESCRIPTION
In preparation for submodules in Mir this commit introduces structured
module IDs. They are backwards-compatible with the old unstructured
ones, which are considered to be identifiers of top-level modules.
