### PR TITLE
Generate protobufs first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ lint:
 
 .PHONY: generate
 generate:
+	go generate ./protos # Generate basic protobufs first, as those might be necessary to generate the rest.
 	go generate ./...
 
 samples: $(targetdir)/chat-demo


### PR DESCRIPTION
If the generated protobufs are broken (e.g. during a git rebase), running `make generate` used to return an error, because it tried to compile them first with Go. Now the `./protos` are generated first.