### PR TITLE
Event backpressure

### DIFF
--- a/cmd/bench/cmd/node.go
+++ b/cmd/bench/cmd/node.go
@@ -89,7 +89,7 @@ func runNode() error {
 	stat := stats.NewStats()
 	interceptor := stats.NewStatInterceptor(stat, "app")
 
-	nodeConfig := &mir.NodeConfig{Logger: logger}
+	nodeConfig := mir.DefaultNodeConfig().WithLogger(logger)
 	node, err := mir.NewNode(t.NodeID(id), nodeConfig, benchApp.Modules(), nil, interceptor)
 	if err != nil {
 		return fmt.Errorf("could not create node: %w", err)

--- a/cmd/mircat/debug.go
+++ b/cmd/mircat/debug.go
@@ -139,7 +139,7 @@ func debuggerNode(id t.NodeID, membership map[t.NodeID]t.NodeAddress) (*mir.Node
 		panic(fmt.Errorf("error initializing the Mir modules: %w", err))
 	}
 
-	node, err := mir.NewNode(id, &mir.NodeConfig{Logger: logger}, modulesWithDefaults, nil, nil)
+	node, err := mir.NewNode(id, mir.DefaultNodeConfig().WithLogger(logger), modulesWithDefaults, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not instantiate mir node: %w", err)
 	}

--- a/config.go
+++ b/config.go
@@ -17,13 +17,27 @@ import "github.com/filecoin-project/mir/pkg/logging"
 type NodeConfig struct {
 	// Logger provides the logging functions.
 	Logger logging.Logger
+
+	// PauseInputThreshold is the number of events in the node's internal event buffer that triggers the disabling
+	// of further external input (i.e. events emitted by active modules). Events emitted by passive modules are
+	// not affected. The processing of external events is resumed when the number of events in the buffer drops
+	// below the ResumeInputThreshold.
+	PauseInputThreshold int
+
+	// ResumeInputThreshold is the number of events in the node's internal event buffer that triggers the enabling
+	// of external input (i.e. events emitted by active modules). Events emitted by passive modules are not affected.
+	// When the external input is disabled and the number of events in the buffer drops below ResumeInputThreshold,
+	// external input events can be added to the event buffer again.
+	ResumeInputThreshold int
 }
 
 // DefaultNodeConfig returns the default node configuration.
 // It can be used as a base for creating more specific configurations when instantiating a Node.
 func DefaultNodeConfig() *NodeConfig {
 	return &NodeConfig{
-		Logger: logging.ConsoleInfoLogger,
+		Logger:               logging.ConsoleInfoLogger,
+		PauseInputThreshold:  1024,
+		ResumeInputThreshold: 512,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -26,3 +26,9 @@ func DefaultNodeConfig() *NodeConfig {
 		Logger: logging.ConsoleInfoLogger,
 	}
 }
+
+func (nc *NodeConfig) WithLogger(logger logging.Logger) *NodeConfig {
+	newConfig := *nc
+	newConfig.Logger = logger
+	return &newConfig
+}

--- a/config.go
+++ b/config.go
@@ -18,6 +18,9 @@ type NodeConfig struct {
 	// Logger provides the logging functions.
 	Logger logging.Logger
 
+	// MaxEventBatchSize is the maximum number of events that can be dispatched to a module in a single batch.
+	MaxEventBatchSize int
+
 	// PauseInputThreshold is the number of events in the node's internal event buffer that triggers the disabling
 	// of further external input (i.e. events emitted by active modules). Events emitted by passive modules are
 	// not affected. The processing of external events is resumed when the number of events in the buffer drops
@@ -36,8 +39,9 @@ type NodeConfig struct {
 func DefaultNodeConfig() *NodeConfig {
 	return &NodeConfig{
 		Logger:               logging.ConsoleInfoLogger,
-		PauseInputThreshold:  1024,
-		ResumeInputThreshold: 512,
+		MaxEventBatchSize:    512,
+		PauseInputThreshold:  8192,
+		ResumeInputThreshold: 6144,
 	}
 }
 

--- a/eventbuffer.go
+++ b/eventbuffer.go
@@ -17,9 +17,9 @@ type eventBuffer struct {
 }
 
 // newEventBuffer allocates and returns a pointer to a new eventBuffer object.
-func newEventBuffer(modules modules.Modules) *eventBuffer {
+func newEventBuffer(modules modules.Modules) eventBuffer {
 
-	wi := &eventBuffer{
+	wi := eventBuffer{
 		buffers:     make(map[t.ModuleID]*events.EventList),
 		totalEvents: 0,
 	}
@@ -35,6 +35,8 @@ func newEventBuffer(modules modules.Modules) *eventBuffer {
 // According to their DestModule fields, the events are distributed to the appropriate internal sub-buffers.
 // When AddEvents returns a non-nil error, any subset of the events may have been added.
 func (wi *eventBuffer) AddEvents(events *events.EventList) error {
+	// Note that this MUST be a pointer receiver.
+	// Otherwise, we'd increment a copy of the event counter rather than the counter itself.
 	iter := events.Iterator()
 
 	// For each incoming event

--- a/node.go
+++ b/node.go
@@ -53,7 +53,7 @@ type Node struct {
 
 	// A buffer for storing outstanding events that need to be processed by the node.
 	// It contains a separate sub-buffer for each type of event.
-	workItems *eventBuffer
+	workItems eventBuffer
 
 	// Channels for routing work items between modules.
 	// Whenever workItems contains events, those events will be written (by the process() method)

--- a/node_test.go
+++ b/node_test.go
@@ -55,7 +55,7 @@ func TestNode_Run(t *testing.T) {
 			logger := logging.ConsoleWarnLogger
 			n, err := NewNode(
 				"testnode",
-				&NodeConfig{Logger: logger},
+				DefaultNodeConfig().WithLogger(logger),
 				m,
 				nil,
 				nil,

--- a/node_test.go
+++ b/node_test.go
@@ -2,18 +2,23 @@ package mir
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/mir/pkg/events"
 	"github.com/filecoin-project/mir/pkg/logging"
 	"github.com/filecoin-project/mir/pkg/modules"
 	"github.com/filecoin-project/mir/pkg/modules/mockmodules"
+	"github.com/filecoin-project/mir/pkg/pb/eventpb"
 	"github.com/filecoin-project/mir/pkg/types"
+	"github.com/filecoin-project/mir/pkg/util/sliceutil"
 )
 
 func TestNode_Run(t *testing.T) {
@@ -81,4 +86,128 @@ func TestNode_Run(t *testing.T) {
 			<-nodeStopped
 		})
 	}
+}
+
+func TestNode_Backpressure(t *testing.T) {
+
+	nodeConfig := DefaultNodeConfig()
+
+	// Set an input event rate that would fill the node's event buffers in one second in 10 batches.
+	blabberModule := newBlabber(uint64(nodeConfig.PauseInputThreshold/10), 100*time.Millisecond)
+
+	// Set the event consumption rate to 1/2 of the input rate (i.e., draining the buffer in 2 seconds)
+	// and create the consumer module.
+	consumerDelay := 2 * time.Second / time.Duration(nodeConfig.PauseInputThreshold)
+	consumerModule := newConsumer(consumerDelay)
+
+	// Instantiate node with a fast blabber module and a slow consumer module.
+	n, err := NewNode(
+		"testnode",
+		DefaultNodeConfig(),
+		map[types.ModuleID]modules.Module{
+			"blabber":  blabberModule,
+			"consumer": consumerModule,
+		},
+		nil,
+		nil,
+	)
+	assert.Nil(t, err)
+
+	// Start a flood of dummy events.
+	blabberModule.Go()
+
+	// Start the node.
+	nodeError := make(chan error)
+	go func() {
+		nodeError <- n.Run(context.Background())
+	}()
+
+	// Run for 5 seconds, then stop the node.
+	time.Sleep(5 * time.Second)
+	n.Stop()
+	err = <-nodeError
+	fmt.Printf("node error: %v\n", err)
+	assert.True(t, errors.Is(err, ErrStopped), "unexpected node error: \"%v\", expected \"%v\"", err, ErrStopped)
+
+	// The number of submitted events must not exceed the number of consumed events by too much
+	// (accounting for events still in the buffer and the overshooting caused by batched adding of events).
+	fmt.Printf("Total submitted events: %d\n", atomic.LoadUint64(&blabberModule.totalSubmitted))
+	totalSubmitted := atomic.LoadUint64(&blabberModule.totalSubmitted)
+	expectSubmitted := atomic.LoadUint64(&consumerModule.numProcessed) +
+		uint64(nodeConfig.PauseInputThreshold) + // Events left in the buffer
+		uint64(nodeConfig.MaxEventBatchSize) + // Events in the consumer's processing queue
+		2*blabberModule.batchSize // one batch of overshooting, one batch waiting in the babbler's output channel.
+	assert.LessOrEqual(t, totalSubmitted, expectSubmitted, "too many events submitted (node event buffer overflow)")
+
+}
+
+// =================================================================================================
+// Blabber module (for testing event backpressure)
+// =================================================================================================
+
+// The babbler is a simple ActiveModule that just produces batches of dummy events at a given rate.
+type blabber struct {
+	flood          chan *events.EventList // Output channel for batches of dummy events.
+	batchSize      uint64                 // Number of events output at once.
+	period         time.Duration          // Time between batches.
+	totalSubmitted uint64                 // Counter for total number of submitted events.
+}
+
+func newBlabber(batchSize uint64, period time.Duration) *blabber {
+	return &blabber{
+		flood:     make(chan *events.EventList),
+		batchSize: batchSize,
+		period:    period,
+	}
+}
+
+// Go starts babbling, i.e., producing batches of dummy events at the rate configured at instantiation.
+// Once started, the babbler is unstoppable and keeps babbling forever.
+func (b *blabber) Go() {
+	go func() {
+		for {
+			evts := events.ListOf(sliceutil.Repeat(events.TestingUint("consumer", 0), int(b.batchSize))...)
+			b.flood <- evts
+			atomic.AddUint64(&b.totalSubmitted, b.batchSize)
+			time.Sleep(b.period)
+		}
+	}()
+}
+
+func (b *blabber) ImplementsModule() {}
+
+func (b *blabber) ApplyEvents(_ context.Context, _ *events.EventList) error {
+	return nil
+}
+
+func (b *blabber) EventsOut() <-chan *events.EventList {
+	return b.flood
+}
+
+// =================================================================================================
+// Consumer module (for testing event backpressure)
+// =================================================================================================
+
+// The consumer is a simple passive module that consumes events at a given rate.
+// It treats each event as a noop and just counts the number of events it has processed.
+type consumer struct {
+	delay        time.Duration
+	numProcessed uint64
+}
+
+func newConsumer(delay time.Duration) *consumer {
+	return &consumer{delay: delay}
+}
+
+func (c *consumer) ImplementsModule() {}
+
+// ApplyEvents increments a counter and sleeps for a given duration (set at module instantiation)
+// for each event in the given list.
+func (c *consumer) ApplyEvents(evts *events.EventList) (*events.EventList, error) {
+	evtsOut, err := modules.ApplyEventsSequentially(evts, func(event *eventpb.Event) (*events.EventList, error) {
+		atomic.AddUint64(&c.numProcessed, 1)
+		time.Sleep(c.delay)
+		return events.EmptyList(), nil
+	})
+	return evtsOut, err
 }

--- a/pkg/deploytest/deployment.go
+++ b/pkg/deploytest/deployment.go
@@ -103,9 +103,7 @@ func NewDeployment(conf *TestConfig) (*Deployment, error) {
 	for i, nodeID := range conf.NodeIDs {
 
 		// Configure the test replica's node.
-		config := &mir.NodeConfig{
-			Logger: logging.Decorate(conf.Logger, fmt.Sprintf("Node %d: ", i)),
-		}
+		config := mir.DefaultNodeConfig().WithLogger(logging.Decorate(conf.Logger, fmt.Sprintf("Node %d: ", i)))
 
 		// Create instance of TestReplica.
 		replicas[i] = &TestReplica{

--- a/pkg/events/eventlist.go
+++ b/pkg/events/eventlist.go
@@ -83,6 +83,43 @@ func (el *EventList) PushBackList(newEvents *EventList) *EventList {
 	return el
 }
 
+// Head returns the first up to n events in the list as a new list.
+// The original list is not modified.
+func (el *EventList) Head(n int) *EventList {
+	if el.list == nil {
+		return EmptyList()
+	}
+
+	result := EmptyList()
+	iter := el.Iterator()
+	for i := 0; i < n; i++ {
+		event := iter.Next()
+		if event == nil {
+			break
+		}
+		result.PushBack(event)
+	}
+	return result
+}
+
+// RemoveFront removes the first up to n events from the list.
+// Returns the number of events actually removed.
+func (el *EventList) RemoveFront(n int) int {
+	if el.list == nil {
+		return 0
+	}
+
+	for i := 0; i < n; i++ {
+		if first := el.list.Front(); first != nil {
+			el.list.Remove(first)
+		} else {
+			return i
+		}
+	}
+
+	return n
+}
+
 // Slice returns a slice representation of the current state of the list.
 // The returned slice only contains pointers to the events in this list, no deep copying is performed.
 // Any modifications performed on the events will affect the contents of both the EventList and the returned slice.

--- a/samples/availability-layer-demo/client.go
+++ b/samples/availability-layer-demo/client.go
@@ -132,7 +132,7 @@ func run() error {
 	}
 
 	// create a Mir node
-	node, err := mir.NewNode("client", &mir.NodeConfig{Logger: logger}, m, nil, nil)
+	node, err := mir.NewNode("client", mir.DefaultNodeConfig().WithLogger(logger), m, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error creating a Mir node: %w", err)
 	}

--- a/samples/bcb-demo/client.go
+++ b/samples/bcb-demo/client.go
@@ -111,7 +111,7 @@ func run() error {
 	}
 
 	// create a Mir node
-	node, err := mir.NewNode("client", &mir.NodeConfig{Logger: logger}, m, nil, nil)
+	node, err := mir.NewNode("client", mir.DefaultNodeConfig().WithLogger(logger), m, nil, nil)
 	if err != nil {
 		return fmt.Errorf("error creating a Mir node: %w", err)
 	}

--- a/samples/chat-demo/main.go
+++ b/samples/chat-demo/main.go
@@ -126,7 +126,7 @@ func run() error {
 		return errors.Wrap(err, "could not start SMR system")
 	}
 
-	node, err := mir.NewNode(args.OwnID, &mir.NodeConfig{Logger: logger}, smrSystem.Modules(), nil, nil)
+	node, err := mir.NewNode(args.OwnID, mir.DefaultNodeConfig().WithLogger(logger), smrSystem.Modules(), nil, nil)
 	if err != nil {
 		return errors.Wrap(err, "could not create node")
 	}


### PR DESCRIPTION
This PR implements backpressure for event processing within a node.

Active modules now cannot make the node's event buffers explode in size, as the node stops reading input from active modules when its internal event buffer grows above a configurable limit.

The limit on the internal event buffer is a "soft limit" in the sense that as long as there are fewer events than the limit in the buffer, an arbitrary event list can be added, which might result in the buffer's actual size "overshooting" the limit, if the event list being added is long. This should not be a big problem in practice though, as the list already occupies space in memory and the events are simply "moved" to the buffer, without creating another copy.

Resolves #100 .
Resolves #238 .