### PR TITLE
hotfix: multiaddr comparison

### DIFF
--- a/pkg/systems/smr/system.go
+++ b/pkg/systems/smr/system.go
@@ -91,7 +91,7 @@ func New(
 	for _, addr := range h.Addrs() {
 		// sanity-check to see if the host is configured with the
 		// right multiaddr.
-		if addr == initialMembership[ownID] {
+		if addr.Equal(initialMembership[ownID]) {
 			addrIn = true
 			break
 		}


### PR DESCRIPTION
Fix multiaddr comparison. There was a bug because `addr` and `t.nodeAddress` were consider of different types.