### PR TITLE
Fix locking bug in libp2p transport

### DIFF
--- a/pkg/net/libp2p/libp2p_transport.go
+++ b/pkg/net/libp2p/libp2p_transport.go
@@ -310,6 +310,7 @@ func (t *Transport) connectToNode(ctx context.Context, nodeID types.NodeID) {
 	}
 
 	if conn.Connecting {
+		t.connsLock.Unlock()
 		t.logger.Log(logging.LevelError, "already connecting", "src", t.ownID, "dst", nodeID)
 		return
 	}

--- a/pkg/net/libp2p/libp2p_transport_test.go
+++ b/pkg/net/libp2p/libp2p_transport_test.go
@@ -430,6 +430,7 @@ func TestLibp2p_Sending2Nodes(t *testing.T) {
 
 	nodeBEventsChan := b.EventsOut()
 
+	a.WaitFor(2)
 	err := a.Send(ctx, nodeB, &messagepb.Message{})
 
 	require.NoError(t, err)
@@ -484,6 +485,7 @@ func TestLibp2p_Sending2NodesNonBlock(t *testing.T) {
 	a.Connect(ctx, initialNodes)
 	b.Connect(ctx, initialNodes)
 	m.testEventuallyConnected(nodeA, nodeB)
+	a.WaitFor(2)
 
 	t.Log(">>> send a message")
 	err := a.Send(ctx, nodeB, &messagepb.Message{})

--- a/pkg/systems/smr/system.go
+++ b/pkg/systems/smr/system.go
@@ -58,7 +58,6 @@ func (sys *System) Start(ctx context.Context) error {
 		return errors.Wrap(err, "could not start network transport")
 	}
 	sys.transport.Connect(ctx, sys.initialMembership)
-	sys.transport.WaitFor(len(sys.initialMembership))
 	return nil
 }
 


### PR DESCRIPTION
Also, don't wait for all nodes to be connected in SMR system.
