### PR TITLE
Improve module error propagation

### DIFF
--- a/pkg/deploytest/simulation.go
+++ b/pkg/deploytest/simulation.go
@@ -246,8 +246,7 @@ func (m *simModule) run(proc *testsim.Process, applyFn applyEventsFn) {
 
 			proc.Yield() // wait until any other process blocks
 		} else {
-			proc.Exit()
-			return
+			panic(out.err)
 		}
 	}
 }

--- a/pkg/modules/eventprocessing.go
+++ b/pkg/modules/eventprocessing.go
@@ -86,7 +86,9 @@ func ApplyEventsConcurrently(
 		//            as they are being written by the worker goroutines, otherwise the system gets stuck.
 
 		// Read results from common channel and add it to the accumulator.
-		eventsOut.PushBackList(<-results[i])
+		if evList := <-results[i]; evList != nil {
+			eventsOut.PushBackList(evList)
+		}
 
 		// Read error from common channel.
 		// We only consider the first error, as ApplyEventsConcurrently only returns a single error.

--- a/pkg/threshcrypto/threshcrypto.go
+++ b/pkg/threshcrypto/threshcrypto.go
@@ -34,7 +34,7 @@ func (c *MirModule) ApplyEvent(event *eventpb.Event) (*events.EventList, error) 
 		return c.applyTCEvent(e.ThreshCrypto)
 	default:
 		// Complain about all other incoming event types.
-		return nil, fmt.Errorf("unexpected type of MirModule event: %T", event.Type)
+		return nil, fmt.Errorf("unexpected type of event in threshcrypto MirModule: %T", event.Type)
 	}
 }
 
@@ -84,7 +84,7 @@ func (c *MirModule) applyTCEvent(event *threshcryptopb.Event) (*events.EventList
 		), nil
 	default:
 		// Complain about all other incoming event types.
-		return nil, fmt.Errorf("unexpected type of MirModule threshcrypto event: %T", event.Type)
+		return nil, fmt.Errorf("unexpected type of threshcrypto event in threshcrypto MirModule: %T", event.Type)
 	}
 }
 


### PR DESCRIPTION
I accidentally sent `SendMessage` events to the threshcrypto module and got a cryptic error message.

This PR fixes error propagation in `ApplyEventsConcurrently`, and aborts simulations when modules produce errors.

Aborting sounds like the appropriate behavior because right now the error I described (sending events to the wrong module) will just quietly exit the simulated process and hang the test until it timeouts.