### PR TITLE
Deliver padding blocks

### DIFF
--- a/pkg/net/libp2p/params.go
+++ b/pkg/net/libp2p/params.go
@@ -26,7 +26,7 @@ func DefaultParams() Params {
 
 		ProtocolID:             "/mir/0.0.1",
 		MaxConnectingTimeout:   10 * time.Second,
-		MaxRetryTimeout:        20 * time.Second,
+		MaxRetryTimeout:        1 * time.Second,
 		MaxRetries:             10,
 		NoLoggingErrorAttempts: 2,
 		PermanentAddrTTL:       DefaultPermanentAddrTTL,


### PR DESCRIPTION
Padding blocks (resulting from view changes) have been ignored and not delivered to the application at all, which was confusing the application with respect to checkpoints (it expects to receive a certain number of blocks between checkpoints).

We now deliver empty blocks on reception of such padding certificates.