### PR TITLE
Add filter by destination module to mircat

### DIFF
--- a/cmd/mircat/debug.go
+++ b/cmd/mircat/debug.go
@@ -89,7 +89,7 @@ func debug(args *arguments) error {
 
 			// If the event was selected by the user for inspection, pause before submitting it to the node.
 			// The processing continues after the user's interactive confirmation.
-			if selected(event, args.selectedEvents, args.selectedIssEvents) &&
+			if selected(event, args.selectedEventNames, args.selectedIssEventNames) &&
 				index >= args.offset &&
 				(args.limit == 0 || index < args.offset+args.limit) {
 

--- a/cmd/mircat/display.go
+++ b/cmd/mircat/display.go
@@ -40,13 +40,16 @@ func displayEvents(args *arguments) error {
 		for _, event := range entry.Events {
 			metadata.index = uint64(index)
 
-			if _, ok := args.selectedEvents[eventName(event)]; ok && index >= args.offset && (args.limit == 0 || index < args.offset+args.limit) {
+			_, validEvent := args.selectedEventNames[eventName(event)]
+			_, validDest := args.selectedEventDests[event.DestModule]
+
+			if validEvent && validDest && index >= args.offset && (args.limit == 0 || index < args.offset+args.limit) {
 				// If event type has been selected for displaying
 
 				switch e := event.Type.(type) {
 				case *eventpb.Event_Iss:
 					// Only display selected sub-types of the ISS Event
-					if _, ok := args.selectedIssEvents[issEventName(e.Iss)]; ok {
+					if _, validIssEvent := args.selectedIssEventNames[issEventName(e.Iss)]; validIssEvent {
 						displayEvent(event, metadata)
 					}
 				default:

--- a/cmd/mircat/main.go
+++ b/cmd/mircat/main.go
@@ -31,10 +31,13 @@ type arguments struct {
 	limit int
 
 	// Events selected by the user for displaying.
-	selectedEvents map[string]struct{}
+	selectedEventNames map[string]struct{}
 
 	// If ISS Events have been selected for displaying, this variable contains the types of ISS events to be displayed.
-	selectedIssEvents map[string]struct{}
+	selectedIssEventNames map[string]struct{}
+
+	// Events with specific destination modules selected by the user for displaying
+	selectedEventDests map[string]struct{}
 
 	// If set to true, start a Node in debug mode with the given event log.
 	debug bool
@@ -64,7 +67,7 @@ func main() {
 
 	// Scan the event log and collect all occurring event types.
 	fmt.Println("Scanning input file.")
-	allEvents, allISSEvents, totalEvents, err := getEventList(args.srcFile)
+	allEvents, allISSEvents, allDests, totalEvents, err := getEventList(args.srcFile)
 	if err != nil {
 		kingpin.Errorf("Error parsing src file", err)
 		fmt.Printf("\n\n!!!\nContinuing after error. Event list might be incomplete!\n!!!\n\n")
@@ -73,22 +76,29 @@ func main() {
 
 	// If no event types have been selected through command-line arguments,
 	// have the user interactively select the events to include in the output.
-	if len(args.selectedEvents) == 0 {
+	if len(args.selectedEventNames) == 0 {
 
 		// Select top-level events
-		args.selectedEvents = checkboxes("Please select the events", allEvents)
+		args.selectedEventNames = checkboxes("Please select the events", allEvents)
 
 		// If any ISS events occur in the event log and the user selected the ISS event type,
 		// have the user select which of those should be included in the output.
-		if _, ok := args.selectedEvents["Iss"]; ok {
-			args.selectedIssEvents = checkboxes("Please select the ISS events", allISSEvents)
+		if _, ok := args.selectedEventNames["Iss"]; ok {
+			args.selectedIssEventNames = checkboxes("Please select the ISS events", allISSEvents)
 		}
-
-		// Print the command-line arguments representing the user's selection of events.
-		// This is useful for repeated runs of mircat.
-		fmt.Println("Command-line arguments for selecting the chosen events:\n" +
-			selectionArgs(args.selectedEvents, args.selectedIssEvents))
 	}
+
+	// // If no event destinations have been selected through command-line arguments,
+	// // have the user interactively select the event destinations' to include in the output.
+	if len(args.selectedEventDests) == 0 {
+
+		// Select top-level events
+		args.selectedEventDests = checkboxes("Please select the event destinations", allDests)
+
+	}
+
+	fmt.Println("Command-line arguments for selecting the chosen filters:\n" +
+		selectionArgs(args.selectedEventNames, args.selectedIssEventNames, args.selectedEventDests))
 
 	// Display selected events or enter debug mode.
 	if args.debug {
@@ -115,6 +125,7 @@ func parseArgs(args []string) (*arguments, error) {
 	src := app.Flag("src", "The input file to read.").Required().File()
 	events := app.Flag("event", "Event types to be displayed.").Short('e').Strings()
 	issEvents := app.Flag("iss-event", "Types of ISS Events to be displayed if ISS events are selected.").Short('s').Strings()
+	eventDests := app.Flag("event-dest", "Event destination types to be displayed.").Short('r').Strings()
 	offset := app.Flag("offset", "The first offset events will not be displayed.").Default("0").Int()
 	limit := app.Flag("limit", "Maximum number of events to consider for display or debug").Default("0").Int()
 	dbg := app.Flag("debug", "Start a Node in debug mode with the given event log.").Short('d').Bool()
@@ -131,15 +142,16 @@ func parseArgs(args []string) (*arguments, error) {
 	}
 
 	return &arguments{
-		srcFile:           *src,
-		debug:             *dbg,
-		ownID:             t.NodeID(*id),
-		membership:        t.NodeIDSlice(*membership),
-		showNodeEvents:    *showNodeEvents,
-		offset:            *offset,
-		limit:             *limit,
-		selectedEvents:    toSet(*events),
-		selectedIssEvents: toSet(*issEvents),
+		srcFile:               *src,
+		debug:                 *dbg,
+		ownID:                 t.NodeID(*id),
+		membership:            t.NodeIDSlice(*membership),
+		showNodeEvents:        *showNodeEvents,
+		offset:                *offset,
+		limit:                 *limit,
+		selectedEventNames:    toSet(*events),
+		selectedIssEventNames: toSet(*issEvents),
+		selectedEventDests:    toSet(*eventDests),
 	}, nil
 }
 
@@ -160,7 +172,7 @@ func checkboxes(label string, opts map[string]struct{}) map[string]struct{} {
 	return toSet(selected)
 }
 
-func selectionArgs(events map[string]struct{}, issEvents map[string]struct{}) string {
+func selectionArgs(events map[string]struct{}, issEvents map[string]struct{}, dests map[string]struct{}) string {
 	argStr := ""
 
 	for _, eventName := range toList(events) {
@@ -169,6 +181,10 @@ func selectionArgs(events map[string]struct{}, issEvents map[string]struct{}) st
 
 	for _, issEventName := range toList(issEvents) {
 		argStr += " --iss-event " + issEventName
+	}
+
+	for _, dest := range toList(dests) {
+		argStr += " event-dest " + dest
 	}
 
 	return argStr

--- a/pkg/modules/mockmodules/internal/mock_internal/impl.mock.go
+++ b/pkg/modules/mockmodules/internal/mock_internal/impl.mock.go
@@ -7,9 +7,10 @@ package mock_internal
 import (
 	reflect "reflect"
 
+	gomock "github.com/golang/mock/gomock"
+
 	events "github.com/filecoin-project/mir/pkg/events"
 	eventpb "github.com/filecoin-project/mir/pkg/pb/eventpb"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockModuleImpl is a mock of ModuleImpl interface.

--- a/pkg/net/grpc/grpctransport.pb.go
+++ b/pkg/net/grpc/grpctransport.pb.go
@@ -12,11 +12,13 @@
 package grpc
 
 import (
-	messagepb "github.com/filecoin-project/mir/pkg/pb/messagepb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
+	messagepb "github.com/filecoin-project/mir/pkg/pb/messagepb"
 )
 
 const (

--- a/pkg/net/grpc/grpctransport_grpc.pb.go
+++ b/pkg/net/grpc/grpctransport_grpc.pb.go
@@ -4,6 +4,7 @@ package grpc
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/pkg/pb/availabilitypb/availabilitypb.pb.go
+++ b/pkg/pb/availabilitypb/availabilitypb.pb.go
@@ -7,15 +7,17 @@
 package availabilitypb
 
 import (
+	reflect "reflect"
+	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
 	mscpb "github.com/filecoin-project/mir/pkg/pb/availabilitypb/mscpb"
 	contextstorepb "github.com/filecoin-project/mir/pkg/pb/contextstorepb"
 	dslpb "github.com/filecoin-project/mir/pkg/pb/dslpb"
 	_ "github.com/filecoin-project/mir/pkg/pb/mir"
 	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/pb/availabilitypb/batchdbpb/batchdbpb.pb.go
+++ b/pkg/pb/availabilitypb/batchdbpb/batchdbpb.pb.go
@@ -7,14 +7,16 @@
 package batchdbpb
 
 import (
+	reflect "reflect"
+	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
 	contextstorepb "github.com/filecoin-project/mir/pkg/pb/contextstorepb"
 	dslpb "github.com/filecoin-project/mir/pkg/pb/dslpb"
 	_ "github.com/filecoin-project/mir/pkg/pb/mir"
 	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/pb/availabilitypb/mscpb/mscpb.pb.go
+++ b/pkg/pb/availabilitypb/mscpb/mscpb.pb.go
@@ -7,12 +7,14 @@
 package mscpb
 
 import (
-	commonpb "github.com/filecoin-project/mir/pkg/pb/commonpb"
-	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
+	commonpb "github.com/filecoin-project/mir/pkg/pb/commonpb"
+	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
 )
 
 const (

--- a/pkg/pb/batchfetcherpb/batchfetcherpb.pb.go
+++ b/pkg/pb/batchfetcherpb/batchfetcherpb.pb.go
@@ -7,13 +7,15 @@
 package batchfetcherpb
 
 import (
+	reflect "reflect"
+	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
 	commonpb "github.com/filecoin-project/mir/pkg/pb/commonpb"
 	_ "github.com/filecoin-project/mir/pkg/pb/mir"
 	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/pb/bcbpb/bcbpb.pb.go
+++ b/pkg/pb/bcbpb/bcbpb.pb.go
@@ -7,11 +7,13 @@
 package bcbpb
 
 import (
-	_ "github.com/filecoin-project/mir/pkg/pb/mir"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
+	_ "github.com/filecoin-project/mir/pkg/pb/mir"
 )
 
 const (

--- a/pkg/pb/checkpointpb/checkpointpb.pb.go
+++ b/pkg/pb/checkpointpb/checkpointpb.pb.go
@@ -7,11 +7,13 @@
 package checkpointpb
 
 import (
-	commonpb "github.com/filecoin-project/mir/pkg/pb/commonpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
+	commonpb "github.com/filecoin-project/mir/pkg/pb/commonpb"
 )
 
 const (

--- a/pkg/pb/commonpb/commonpb.pb.go
+++ b/pkg/pb/commonpb/commonpb.pb.go
@@ -7,10 +7,11 @@
 package commonpb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pkg/pb/contextstorepb/contextstorepb.pb.go
+++ b/pkg/pb/contextstorepb/contextstorepb.pb.go
@@ -7,10 +7,11 @@
 package contextstorepb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pkg/pb/dslpb/dslpb.pb.go
+++ b/pkg/pb/dslpb/dslpb.pb.go
@@ -7,10 +7,11 @@
 package dslpb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pkg/pb/eventpb/eventpb.pb.go
+++ b/pkg/pb/eventpb/eventpb.pb.go
@@ -12,6 +12,13 @@
 package eventpb
 
 import (
+	reflect "reflect"
+	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
+
 	availabilitypb "github.com/filecoin-project/mir/pkg/pb/availabilitypb"
 	batchdbpb "github.com/filecoin-project/mir/pkg/pb/availabilitypb/batchdbpb"
 	batchfetcherpb "github.com/filecoin-project/mir/pkg/pb/batchfetcherpb"
@@ -28,11 +35,6 @@ import (
 	pingpongpb "github.com/filecoin-project/mir/pkg/pb/pingpongpb"
 	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
 	threshcryptopb "github.com/filecoin-project/mir/pkg/pb/threshcryptopb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/pb/eventpb/eventpb.pb.mir.go
+++ b/pkg/pb/eventpb/eventpb.pb.mir.go
@@ -1,6 +1,8 @@
 package eventpb
 
 import (
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
+
 	availabilitypb "github.com/filecoin-project/mir/pkg/pb/availabilitypb"
 	batchdbpb "github.com/filecoin-project/mir/pkg/pb/availabilitypb/batchdbpb"
 	batchfetcherpb "github.com/filecoin-project/mir/pkg/pb/batchfetcherpb"
@@ -11,7 +13,6 @@ import (
 	mempoolpb "github.com/filecoin-project/mir/pkg/pb/mempoolpb"
 	pingpongpb "github.com/filecoin-project/mir/pkg/pb/pingpongpb"
 	threshcryptopb "github.com/filecoin-project/mir/pkg/pb/threshcryptopb"
-	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 type Event_Type = isEvent_Type

--- a/pkg/pb/factorymodulepb/factorymodulepb.pb.go
+++ b/pkg/pb/factorymodulepb/factorymodulepb.pb.go
@@ -7,12 +7,14 @@
 package factorymodulepb
 
 import (
-	mscpb "github.com/filecoin-project/mir/pkg/pb/availabilitypb/mscpb"
-	checkpointpb "github.com/filecoin-project/mir/pkg/pb/checkpointpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
+	mscpb "github.com/filecoin-project/mir/pkg/pb/availabilitypb/mscpb"
+	checkpointpb "github.com/filecoin-project/mir/pkg/pb/checkpointpb"
 )
 
 const (

--- a/pkg/pb/isspb/isspb.pb.go
+++ b/pkg/pb/isspb/isspb.pb.go
@@ -12,15 +12,17 @@
 package isspb
 
 import (
+	reflect "reflect"
+	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
 	availabilitypb "github.com/filecoin-project/mir/pkg/pb/availabilitypb"
 	checkpointpb "github.com/filecoin-project/mir/pkg/pb/checkpointpb"
 	commonpb "github.com/filecoin-project/mir/pkg/pb/commonpb"
 	isspbftpb "github.com/filecoin-project/mir/pkg/pb/isspbftpb"
 	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/pb/isspbftpb/isspbftpb.pb.go
+++ b/pkg/pb/isspbftpb/isspbftpb.pb.go
@@ -12,10 +12,11 @@
 package isspbftpb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pkg/pb/mempoolpb/mempoolpb.pb.go
+++ b/pkg/pb/mempoolpb/mempoolpb.pb.go
@@ -7,14 +7,16 @@
 package mempoolpb
 
 import (
+	reflect "reflect"
+	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
 	contextstorepb "github.com/filecoin-project/mir/pkg/pb/contextstorepb"
 	dslpb "github.com/filecoin-project/mir/pkg/pb/dslpb"
 	_ "github.com/filecoin-project/mir/pkg/pb/mir"
 	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/pb/messagepb/messagepb.pb.go
+++ b/pkg/pb/messagepb/messagepb.pb.go
@@ -12,15 +12,17 @@
 package messagepb
 
 import (
+	reflect "reflect"
+	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
 	mscpb "github.com/filecoin-project/mir/pkg/pb/availabilitypb/mscpb"
 	bcbpb "github.com/filecoin-project/mir/pkg/pb/bcbpb"
 	checkpointpb "github.com/filecoin-project/mir/pkg/pb/checkpointpb"
 	isspb "github.com/filecoin-project/mir/pkg/pb/isspb"
 	pingpongpb "github.com/filecoin-project/mir/pkg/pb/pingpongpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/pb/mir/plugin.pb.go
+++ b/pkg/pb/mir/plugin.pb.go
@@ -7,10 +7,11 @@
 package mir
 
 import (
+	reflect "reflect"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
-	reflect "reflect"
 )
 
 const (

--- a/pkg/pb/pingpongpb/pingpongpb.pb.go
+++ b/pkg/pb/pingpongpb/pingpongpb.pb.go
@@ -7,10 +7,11 @@
 package pingpongpb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pkg/pb/recordingpb/recordingpb.pb.go
+++ b/pkg/pb/recordingpb/recordingpb.pb.go
@@ -12,11 +12,13 @@
 package recordingpb
 
 import (
-	eventpb "github.com/filecoin-project/mir/pkg/pb/eventpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
+	eventpb "github.com/filecoin-project/mir/pkg/pb/eventpb"
 )
 
 const (

--- a/pkg/pb/requestpb/requestpb.pb.go
+++ b/pkg/pb/requestpb/requestpb.pb.go
@@ -12,10 +12,11 @@
 package requestpb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pkg/pb/threshcryptopb/threshcryptopb.pb.go
+++ b/pkg/pb/threshcryptopb/threshcryptopb.pb.go
@@ -7,13 +7,15 @@
 package threshcryptopb
 
 import (
+	reflect "reflect"
+	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
 	contextstorepb "github.com/filecoin-project/mir/pkg/pb/contextstorepb"
 	dslpb "github.com/filecoin-project/mir/pkg/pb/dslpb"
 	_ "github.com/filecoin-project/mir/pkg/pb/mir"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/pkg/requestreceiver/requestreceiver.pb.go
+++ b/pkg/requestreceiver/requestreceiver.pb.go
@@ -12,11 +12,13 @@
 package requestreceiver
 
 import (
-	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
+	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
 )
 
 const (

--- a/pkg/requestreceiver/requestreceiver_grpc.pb.go
+++ b/pkg/requestreceiver/requestreceiver_grpc.pb.go
@@ -4,10 +4,12 @@ package requestreceiver
 
 import (
 	context "context"
-	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+
+	requestpb "github.com/filecoin-project/mir/pkg/pb/requestpb"
 )
 
 // This is a compile-time assertion to ensure that this generated file

--- a/pkg/simplewal/simplewal.pb.go
+++ b/pkg/simplewal/simplewal.pb.go
@@ -12,11 +12,13 @@
 package simplewal
 
 import (
-	eventpb "github.com/filecoin-project/mir/pkg/pb/eventpb"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+
+	eventpb "github.com/filecoin-project/mir/pkg/pb/eventpb"
 )
 
 const (

--- a/samples/chat-demo/chatdemo.pb.go
+++ b/samples/chat-demo/chatdemo.pb.go
@@ -12,10 +12,11 @@
 package main
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (


### PR DESCRIPTION
mircat can now also filter by destination modules, besides the existing filter by event names. 
Relating #220 