### PR TITLE
Add checkpoint and certificate serialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require github.com/golang/mock v1.6.0
 require (
 	github.com/drand/kyber v1.1.15
 	github.com/drand/kyber-bls12381 v0.2.3
+	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/ipfs/go-cid v0.1.0
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/spf13/cobra v1.5.0
@@ -127,6 +128,7 @@ require (
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/tinylru v1.1.0 // indirect
 	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
+github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -651,6 +653,8 @@ github.com/whyrusleeping/cbor-gen v0.0.0-20220514204315-f29c37e9c44c/go.mod h1:f
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 h1:E9S12nwJwEOXe2d6gT6qxdvqMnNq+VnSsKPgm2ZZNds=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/checkpoint/certificate.go
+++ b/pkg/checkpoint/certificate.go
@@ -1,0 +1,40 @@
+package checkpoint
+
+import (
+	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
+
+	t "github.com/filecoin-project/mir/pkg/types"
+	"github.com/filecoin-project/mir/pkg/util/maputil"
+)
+
+// Certificate represents a certificate of validity of a checkpoint.
+// It is included in a stable checkpoint itself.
+type Certificate map[t.NodeID][]byte
+
+func (cert *Certificate) Pb() map[string][]byte {
+	return maputil.Transform(*cert,
+		func(k t.NodeID) string {
+			return k.Pb()
+		}, func(v []byte) []byte {
+			return v
+		},
+	)
+}
+
+func (cert *Certificate) Serialize() ([]byte, error) {
+	em, err := cbor.CoreDetEncOptions().EncMode()
+	if err != nil {
+		return nil, err
+	}
+
+	return em.Marshal(cert)
+}
+
+func (cert *Certificate) Deserialize(data []byte) error {
+	if err := cbor.Unmarshal(data, cert); err != nil {
+		return fmt.Errorf("failed to CBOR unmarshal checkpoint certificate: %w", err)
+	}
+	return nil
+}

--- a/samples/chat-demo/main.go
+++ b/samples/chat-demo/main.go
@@ -332,7 +332,7 @@ func loadStableCheckpoint(filename string) (retChkp *checkpoint.StableCheckpoint
 	}
 
 	var chkp *checkpoint.StableCheckpoint
-	if chkp, err = checkpoint.DeserializeStableCheckpoint(chkpBytes); err != nil {
+	if err := chkp.Deserialize(chkpBytes); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The stable checkpoint can be now deterministically serialized and deserialized.
The certificate can be added to and removed from the checkpoint.