### PR TITLE
Add rudimentary single-module debugging to mircat

### DIFF
--- a/cmd/mircat/custommodule.go
+++ b/cmd/mircat/custommodule.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/filecoin-project/mir/pkg/modules"
+)
+
+func customModule() modules.PassiveModule {
+
+	return nil
+}

--- a/cmd/mircat/customtransform.go
+++ b/cmd/mircat/customtransform.go
@@ -7,5 +7,12 @@ import "github.com/filecoin-project/mir/pkg/pb/eventpb"
 // If customEventFilter returns nil, the event is ignored (this can be used for additional event filtering).
 // It is meant for ad-hoc editing while debugging, to be able to select events in a fine-grained way.
 func customTransform(e *eventpb.Event) *eventpb.Event {
+
+	//moduleID := ""
+	//if e.DestModule == moduleID {
+	//	return e
+	//}
+	//return nil
+
 	return e
 }

--- a/cmd/mircat/display.go
+++ b/cmd/mircat/display.go
@@ -9,12 +9,13 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/alecthomas/kingpin.v2"
-
 	"github.com/ttacon/chalk"
 	"google.golang.org/protobuf/encoding/protojson"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/filecoin-project/mir/pkg/eventlog"
+	"github.com/filecoin-project/mir/pkg/events"
+	"github.com/filecoin-project/mir/pkg/modules"
 	"github.com/filecoin-project/mir/pkg/pb/eventpb"
 	"github.com/filecoin-project/mir/pkg/pb/recordingpb"
 	t "github.com/filecoin-project/mir/pkg/types"
@@ -22,7 +23,8 @@ import (
 
 // extracts events from eventlog entries and
 // forwards them for display
-func displayEvents(args *arguments) error {
+func displayEvents(args *arguments) error { //nolint:gocognit
+	// TODO: linting is disabled, since this code needs to be substantially re-written anyway.
 
 	// new reader
 
@@ -30,6 +32,12 @@ func displayEvents(args *arguments) error {
 	index := 0
 
 	filenames := strings.Split(*args.src, " ")
+
+	// If debugging a module, instantiate it.
+	var module modules.PassiveModule
+	if args.dbgModule {
+		module = customModule()
+	}
 
 	// Create a reader for the input event log file.
 	for _, filename := range filenames {
@@ -78,6 +86,12 @@ func displayEvents(args *arguments) error {
 						}
 					default:
 						displayEvent(event, metadata)
+					}
+
+					if args.dbgModule {
+						if _, err := module.ApplyEvents(events.ListOf(event)); err != nil {
+							return fmt.Errorf("error replaying event to module: %w", err)
+						}
 					}
 				}
 

--- a/cmd/mircat/main.go
+++ b/cmd/mircat/main.go
@@ -43,6 +43,10 @@ type arguments struct {
 	// If set to true, start a Node in debug mode with the given event log.
 	debug bool
 
+	// When this is true, the selected events are all passed to the custom module.
+	// Note that this is completely separate from normal debugging.
+	dbgModule bool
+
 	// The rest of the fields are only used in debug mode and are otherwise ignored.
 
 	// The ID of the node being debugged.
@@ -133,6 +137,7 @@ func parseArgs(args []string) (*arguments, error) {
 	limit := app.Flag("limit", "Maximum number of events to consider for display or debug").Default("0").Int()
 	dbg := app.Flag("debug", "Start a Node in debug mode with the given event log.").Short('d').Bool()
 	id := app.Flag("own-id", "ID of the node to use for debugging.").String()
+	dbgModule := app.Flag("module", "Debug the custom module.").Bool()
 	membership := app.Flag(
 		"node-id",
 		"ID of one membership node, specified once for each node (debugging only).",
@@ -148,6 +153,7 @@ func parseArgs(args []string) (*arguments, error) {
 	return &arguments{
 		src:                   src,
 		debug:                 *dbg,
+		dbgModule:             *dbgModule,
 		ownID:                 t.NodeID(*id),
 		membership:            t.NodeIDSlice(*membership),
 		showNodeEvents:        *showNodeEvents,


### PR DESCRIPTION
This messes up the `mircat` code even more, but it adds a useful functionality of being able to manually create a module and pass selected events from a trace just to that module.
The `mircat` code needs a very big overhaul, but this PR is not meant to address it.