### PR TITLE
Make sure Interceptor works even if it is nil

### DIFF
--- a/cmd/bench/stats/stat-interceptor.go
+++ b/cmd/bench/stats/stat-interceptor.go
@@ -25,6 +25,15 @@ func NewStatInterceptor(s *Stats, txConsumer t.ModuleID) *StatInterceptor {
 }
 
 func (i *StatInterceptor) Intercept(events *events.EventList) error {
+
+	// Avoid nil dereference if Intercept is called on a nil *Recorder and simply do nothing.
+	// This can happen if a pointer type to *Recorder is assigned to a variable with the interface type Interceptor.
+	// Mir would treat that variable as non-nil, thinking there is an interceptor, and call Intercept() on it.
+	// For more explanation, see https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1
+	if i == nil {
+		return nil
+	}
+
 	it := events.Iterator()
 	for evt := it.Next(); evt != nil; evt = it.Next() {
 

--- a/node.go
+++ b/node.go
@@ -469,6 +469,12 @@ func (n *Node) importEvents(
 // as those will be intercepted separately when processed.
 // Make sure to call the Strip method of the EventList before passing it to interceptEvents.
 func (n *Node) interceptEvents(events *events.EventList) {
+
+	// ATTENTION: n.interceptor is an interface type. If it is assigned the nil value of a concrete type,
+	// this condition will evaluate to true, and Intercept(events) will be called on nil.
+	// The implementation of the concrete type must make sure that calling Intercept even on the nil value
+	// does not cause any problems.
+	// For more explanation, see https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1
 	if n.interceptor != nil {
 		if err := n.interceptor.Intercept(events); err != nil {
 			n.workErrNotifier.Fail(err)

--- a/pkg/eventlog/interceptor.go
+++ b/pkg/eventlog/interceptor.go
@@ -5,10 +5,14 @@ import "github.com/filecoin-project/mir/pkg/events"
 // Interceptor provides a way to gain insight into the internal operation of the node.
 // Before being passed to the respective target modules, Events can be intercepted and logged
 // for later analysis or replaying.
+// An interceptor can be used for other purposes to, e.g., to gather statistical information or provide live monitoring.
 type Interceptor interface {
 
-	// Intercept is called each Time Events are passed to a module, if an Interceptor is present in the node.
-	// The expected behavior of Intercept is to add the intercepted Events to a log for later analysis.
-	// TODO: In the comment, also refer to the way Events can be analyzed or replayed.
+	// Intercept is called by the node each Time Events are passed to a module.
+	// ATTENTION: Since this is an interface type, it can happen that a nil value of a concrete type is used in the node
+	// and, consequently, Intercept(events) will be called on nil.
+	// The implementation of the concrete type must make sure that calling Intercept even on the nil value
+	// does not cause any problems.
+	// For more explanation, see https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1
 	Intercept(events *events.EventList) error
 }

--- a/pkg/eventlog/multiinterceptor.go
+++ b/pkg/eventlog/multiinterceptor.go
@@ -9,6 +9,15 @@ type repeater struct {
 }
 
 func (r *repeater) Intercept(events *events.EventList) error {
+
+	// Avoid nil dereference if Intercept is called on a nil *Recorder and simply do nothing.
+	// This can happen if a pointer type to *Recorder is assigned to a variable with the interface type Interceptor.
+	// Mir would treat that variable as non-nil, thinking there is an interceptor, and call Intercept() on it.
+	// For more explanation, see https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1
+	if r == nil {
+		return nil
+	}
+
 	for _, i := range r.interceptors {
 		if err := i.Intercept(events); err != nil {
 			return err


### PR DESCRIPTION
Since the Interceptor is an interface type, it can happen that a nil value of a concrete type is used in the node and, consequently, Intercept() will be called on nil. The implementation of the concrete type thus must make sure that calling Intercept even on the nil value does not cause any problems.
For more explanation, see https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1

Fixes #326 