### PR TITLE
multisigcollector: Fix nil deref

### DIFF
--- a/pkg/availability/multisigcollector/internal/parts/certverification/certverification.go
+++ b/pkg/availability/multisigcollector/internal/parts/certverification/certverification.go
@@ -97,6 +97,7 @@ func IncludeVerificationOfCertificates(
 			valid, errStr := t.ErrorPb(err)
 			apbdsl.CertVerified(m, context.origin.Module, valid, errStr, context.origin)
 			delete(state.RequestState, reqID)
+			return nil
 		}
 
 		// if we get here, that means so far all received signatures for all certificates in the reqID are verified valid or yet to be verified


### PR DESCRIPTION
During testing I noticed this bug. When processing the NodeSigsVerified event, if they are not `allOk` the request is replied to, deleted, but the handler does not return, leading to a nil deref when acessing the now-deleted request.