### PR TITLE
Event recorder sync writing

### DIFF
--- a/pkg/deploytest/testreplica.go
+++ b/pkg/deploytest/testreplica.go
@@ -70,7 +70,13 @@ func (tr *TestReplica) EventLogFile() string {
 func (tr *TestReplica) Run(ctx context.Context) error {
 
 	// Initialize recording of events.
-	interceptor, err := eventlog.NewRecorder(tr.ID, tr.Dir, logging.Decorate(tr.Config.Logger, "Interceptor: "))
+	interceptor, err := eventlog.NewRecorder(
+		tr.ID,
+		tr.Dir,
+		logging.Decorate(tr.Config.Logger, "Interceptor: "),
+		//eventlog.SyncWriteOpt(),
+	)
+
 	if err != nil {
 		return es.Errorf("error creating interceptor: %w", err)
 	}

--- a/pkg/eventlog/eventwriter.go
+++ b/pkg/eventlog/eventwriter.go
@@ -9,6 +9,7 @@ import (
 
 type EventWriter interface {
 	Write(record EventRecord) error
+	Flush() error
 	Close() error
 }
 

--- a/pkg/eventlog/eventwritergzip.go
+++ b/pkg/eventlog/eventwritergzip.go
@@ -53,6 +53,10 @@ func (w *gzipWriter) Write(record EventRecord) error {
 	})
 }
 
+func (w *gzipWriter) Flush() error {
+	return w.dest.Sync()
+}
+
 func (w *gzipWriter) Close() error {
 	return w.dest.Close()
 }

--- a/pkg/eventlog/eventwritersqlite.go
+++ b/pkg/eventlog/eventwritersqlite.go
@@ -66,6 +66,10 @@ func (w sqliteWriter) Write(record EventRecord) error {
 	return nil
 }
 
+func (w sqliteWriter) Flush() error {
+	return nil
+}
+
 func (w sqliteWriter) Close() error {
 	return w.db.Close()
 }

--- a/pkg/eventlog/recorder.go
+++ b/pkg/eventlog/recorder.go
@@ -57,12 +57,14 @@ type Recorder struct {
 	path           string
 	filter         func(event *eventpb.Event) bool
 	newEventWriter func(dest string, nodeID t.NodeID, logger logging.Logger) (EventWriter, error)
+	syncWrite      bool
 
-	logger    logging.Logger
-	eventC    chan EventRecord
-	doneC     chan struct{}
-	exitC     chan struct{}
-	fileCount int
+	logger     logging.Logger
+	eventC     chan EventRecord
+	doneC      chan struct{}
+	exitC      chan struct{}
+	fileCount  int
+	writerLock sync.Mutex
 
 	exitErr      error
 	exitErrMutex sync.Mutex
@@ -96,6 +98,7 @@ func NewRecorder(
 			return true
 		},
 		newEventWriter: DefaultNewEventWriter,
+		syncWrite:      false,
 		logger:         logger,
 	}
 
@@ -115,6 +118,8 @@ func NewRecorder(
 			}
 		case eventWriterOpt:
 			i.newEventWriter = v
+		case syncWriteOpt:
+			i.syncWrite = true
 		}
 	}
 
@@ -128,14 +133,17 @@ func NewRecorder(
 	}
 	i.dest = writer
 
-	go func() {
-		err := i.run()
-		if err != nil {
-			logger.Log(logging.LevelError, "Interceptor returned with error.", "err", err)
-		} else {
-			logger.Log(logging.LevelDebug, "Interceptor returned successfully.")
-		}
-	}()
+	// Only start background writing goroutine if synchronous writing is not enabled.
+	if !i.syncWrite {
+		go func() {
+			err := i.run()
+			if err != nil {
+				logger.Log(logging.LevelError, "Interceptor returned with error.", "err", err)
+			} else {
+				logger.Log(logging.LevelDebug, "Interceptor returned successfully.")
+			}
+		}()
+	}
 
 	return i, nil
 }
@@ -154,11 +162,28 @@ func (i *Recorder) Intercept(events *events.EventList) error {
 		return nil
 	}
 
-	select {
-	case i.eventC <- EventRecord{
+	record := EventRecord{
 		Events: events,
 		Time:   i.timeSource(),
-	}:
+	}
+
+	// If synchronous writing is enabled, write data and return immediately, without using any channels.
+	if i.syncWrite {
+		i.writerLock.Lock()
+		defer i.writerLock.Unlock()
+
+		if err := i.writeEvents(record); err != nil {
+			return es.Errorf("error writing events: %w", err)
+		}
+		if err := i.dest.Flush(); err != nil {
+			return es.Errorf("error flushing written events: %w", err)
+		}
+		return nil
+	}
+
+	// If writing is asynchronous, pass the record to the background writing goroutine.
+	select {
+	case i.eventC <- record:
 		return nil
 	case <-i.exitC:
 		i.exitErrMutex.Lock()
@@ -171,6 +196,13 @@ func (i *Recorder) Intercept(events *events.EventList) error {
 // Interceptor, and should only be invoked after the mir node has completely
 // exited.  The returned error
 func (i *Recorder) Stop() error {
+
+	// In synchronous mode, the interceptor has nothing to stop.
+	// Since we assume that the Mir node has already completely stopped,
+	// we do not need to worry about concurrent or later invocations of Intercept().
+	if i.syncWrite {
+		return nil
+	}
 
 	// Send stop signal to writer thread and wait for it to stop.
 	close(i.doneC)
@@ -204,38 +236,6 @@ func (i *Recorder) run() (exitErr error) {
 		i.logger.Log(logging.LevelInfo, "Intercepted Events written to event log.", "numEvents", cnt, ", path", i.path)
 	}()
 
-	writeInFiles := func(record EventRecord) error {
-		eventByDests := i.newDests(record)
-		count := 0
-		for _, rec := range eventByDests {
-			if count > 0 {
-				// newDest required
-				dest, err := i.newEventWriter(
-					filepath.Join(i.path, "eventlog"+strconv.Itoa(i.fileCount)),
-					i.nodeID,
-					i.logger,
-				)
-				if err != nil {
-					return err
-				}
-				err = i.dest.Close()
-				if err != nil {
-					return err
-				}
-				i.dest = dest
-				i.fileCount++
-			}
-
-			if rec.Events.Len() != 0 {
-				if err := i.dest.Write(rec.Filter(i.filter)); err != nil {
-					return err
-				}
-			}
-			count++
-		}
-		return nil
-	}
-
 	for {
 		select {
 		case <-i.doneC:
@@ -243,7 +243,7 @@ func (i *Recorder) run() (exitErr error) {
 				select {
 				case record := <-i.eventC:
 
-					if err := writeInFiles(record); err != nil {
+					if err := i.writeEvents(record); err != nil {
 						return es.Errorf("error serializing to stream: %w", err)
 					}
 				default:
@@ -251,10 +251,42 @@ func (i *Recorder) run() (exitErr error) {
 				}
 			}
 		case record := <-i.eventC:
-			if err := writeInFiles(record); err != nil {
+			if err := i.writeEvents(record); err != nil {
 				return es.Errorf("error serializing to stream: %w", err)
 			}
 			cnt++
 		}
 	}
+}
+
+func (i *Recorder) writeEvents(record EventRecord) error {
+	eventByDests := i.newDests(record)
+	count := 0
+	for _, rec := range eventByDests {
+		if count > 0 {
+			// newDest required
+			dest, err := i.newEventWriter(
+				filepath.Join(i.path, "eventlog"+strconv.Itoa(i.fileCount)),
+				i.nodeID,
+				i.logger,
+			)
+			if err != nil {
+				return err
+			}
+			err = i.dest.Close()
+			if err != nil {
+				return err
+			}
+			i.dest = dest
+			i.fileCount++
+		}
+
+		if rec.Events.Len() != 0 {
+			if err := i.dest.Write(rec.Filter(i.filter)); err != nil {
+				return err
+			}
+		}
+		count++
+	}
+	return nil
 }

--- a/pkg/eventlog/recorder.go
+++ b/pkg/eventlog/recorder.go
@@ -244,7 +244,7 @@ func (i *Recorder) run() (exitErr error) {
 				case record := <-i.eventC:
 
 					if err := writeInFiles(record); err != nil {
-						return errors.WithMessage(err, "error serializing to stream")
+						return es.Errorf("error serializing to stream: %w", err)
 					}
 				default:
 					return errStopped
@@ -252,7 +252,7 @@ func (i *Recorder) run() (exitErr error) {
 			}
 		case record := <-i.eventC:
 			if err := writeInFiles(record); err != nil {
-				return errors.WithMessage(err, "error serializing to stream")
+				return es.Errorf("error serializing to stream: %w", err)
 			}
 			cnt++
 		}

--- a/pkg/eventlog/recorderopts.go
+++ b/pkg/eventlog/recorderopts.go
@@ -55,3 +55,9 @@ func EventWriterOpt(
 ) RecorderOpt {
 	return eventWriterOpt(factory)
 }
+
+type syncWriteOpt bool
+
+func SyncWriteOpt() RecorderOpt {
+	return syncWriteOpt(true)
+}


### PR DESCRIPTION
The event recorder can now be instantiated with an option that makes the recorder write all events synchronously within the call to `Intercept`, rather than in the background.