### PR TITLE
Abort faulty availability certificates

### DIFF
--- a/pkg/iss/iss.go
+++ b/pkg/iss/iss.go
@@ -247,8 +247,10 @@ func New(
 
 	apbdsl.UponCertVerified(iss.m, func(valid bool, err string, context *verifyCertContext) error {
 		if !valid {
+			iss.logger.Log(logging.LevelWarn, "Ordered invalid availability certificate.", "err", err)
 			// decide empty cert
 			context.data = []byte{}
+			context.aborted = true
 			// suspect leader
 			iss.LeaderPolicy.Suspect(iss.epoch.Nr(), context.leader)
 		}


### PR DESCRIPTION
This fixes an issue where an invalid availability certificate that has been delivered made it (with data truncated to an empty byte slice) all the way to batch reconstruction and made the system fail. The system did not recognize it as empty, because the aborted flag was false.