### PR TITLE
Fix error in test

### DIFF
--- a/pkg/trantor/testing/smr_test.go
+++ b/pkg/trantor/testing/smr_test.go
@@ -405,7 +405,7 @@ func createDeploymentDir(tb testing.TB, conf *TestConfig) {
 }
 
 func newDeployment(conf *TestConfig) (*deploytest.Deployment, error) {
-	nodeIDs := maputil.GetKeys(conf.NodeIDsWeight)
+	nodeIDs := maputil.GetSortedKeys(conf.NodeIDsWeight)
 	logger := deploytest.NewLogger(conf.Logger)
 
 	var simulation *deploytest.Simulation


### PR DESCRIPTION
The error was only in the deployment of the tests, because of the list of nodeIDs not being sorted when retrieved from the map of weights. This paired with the uneven weights meant that in the end we crashed a replica that took enough power to prevent delivery of any transaction. 

A simple word fixes the bug.