### PR TITLE
Log basic information about event processing in Mir Node

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,6 +9,8 @@ Refactored: 1
 package mir
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 
 	"github.com/filecoin-project/mir/pkg/logging"
@@ -36,6 +38,10 @@ type NodeConfig struct {
 	// When the external input is disabled and the number of events in the buffer drops below ResumeInputThreshold,
 	// external input events can be added to the event buffer again.
 	ResumeInputThreshold int
+
+	// If not zero, the Node will emit a log entry (level Debug) every StatsLogInterval
+	// containing statistics about event processing.
+	StatsLogInterval time.Duration
 }
 
 // DefaultNodeConfig returns the default node configuration.
@@ -46,6 +52,7 @@ func DefaultNodeConfig() *NodeConfig {
 		MaxEventBatchSize:    512,
 		PauseInputThreshold:  8192,
 		ResumeInputThreshold: 6144,
+		StatsLogInterval:     0, // Stats logging disabled by default.
 	}
 }
 

--- a/eventbuffer.go
+++ b/eventbuffer.go
@@ -68,3 +68,12 @@ func (wi *eventBuffer) AddEvents(events *events.EventList) error {
 	}
 	return nil
 }
+
+// Stats returns a map containing the number of buffered events for each module.
+func (wi *eventBuffer) Stats() map[t.ModuleID]int {
+	stats := make(map[t.ModuleID]int)
+	for mID, evts := range wi.buffers {
+		stats[mID] = evts.Len()
+	}
+	return stats
+}

--- a/eventbuffer.go
+++ b/eventbuffer.go
@@ -32,10 +32,10 @@ func newEventBuffer(modules modules.Modules) eventBuffer {
 	return wi
 }
 
-// AddEvents adds events produced by modules to the eventBuffer buffer.
+// Add adds events produced by modules to the eventBuffer buffer.
 // According to their DestModule fields, the events are distributed to the appropriate internal sub-buffers.
-// When AddEvents returns a non-nil error, any subset of the events may have been added.
-func (wi *eventBuffer) AddEvents(events *events.EventList) error {
+// When Add returns a non-nil error, any subset of the events may have been added.
+func (wi *eventBuffer) Add(events *events.EventList) error {
 	// Note that this MUST be a pointer receiver.
 	// Otherwise, we'd increment a copy of the event counter rather than the counter itself.
 	iter := events.Iterator()

--- a/eventbuffer.go
+++ b/eventbuffer.go
@@ -35,7 +35,7 @@ func newEventBuffer(modules modules.Modules) eventBuffer {
 // Add adds events produced by modules to the eventBuffer buffer.
 // According to their DestModule fields, the events are distributed to the appropriate internal sub-buffers.
 // When Add returns a non-nil error, any subset of the events may have been added.
-func (wi *eventBuffer) Add(events *events.EventList) error {
+func (eb *eventBuffer) Add(events *events.EventList) error {
 	// Note that this MUST be a pointer receiver.
 	// Otherwise, we'd increment a copy of the event counter rather than the counter itself.
 	iter := events.Iterator()
@@ -44,9 +44,9 @@ func (wi *eventBuffer) Add(events *events.EventList) error {
 	for event := iter.Next(); event != nil; event = iter.Next() {
 
 		// Look up the corresponding module's buffer and add the event to it.
-		if buffer, ok := wi.buffers[t.ModuleID(event.DestModule).Top()]; ok {
+		if buffer, ok := eb.buffers[t.ModuleID(event.DestModule).Top()]; ok {
 			buffer.PushBack(event)
-			wi.totalEvents++
+			eb.totalEvents++
 		} else {
 
 			// If there is no buffer for the event, check if it is a MessgeReceived event.
@@ -70,9 +70,9 @@ func (wi *eventBuffer) Add(events *events.EventList) error {
 }
 
 // Stats returns a map containing the number of buffered events for each module.
-func (wi *eventBuffer) Stats() map[t.ModuleID]int {
+func (eb *eventBuffer) Stats() map[t.ModuleID]int {
 	stats := make(map[t.ModuleID]int)
-	for mID, evts := range wi.buffers {
+	for mID, evts := range eb.buffers {
 		stats[mID] = evts.Len()
 	}
 	return stats

--- a/node.go
+++ b/node.go
@@ -128,7 +128,7 @@ func NewNode(
 		inputPaused:     false,
 		inputPausedCond: sync.NewCond(&sync.Mutex{}),
 
-		dispatchStats: newDispatchStats(maputil.GetSortedKeys(m)),
+		dispatchStats: newDispatchStats(maputil.GetKeys(m)),
 
 		stopped: make(chan struct{}),
 	}, nil

--- a/node.go
+++ b/node.go
@@ -31,11 +31,11 @@ type Node struct {
 
 	// Incoming events to be processed by the node.
 	// E.g., all modules' output events are written in this channel,
-	// from where the Node processor reads and redistributes the events to their respective workItems buffers.
-	// External events are also funneled through this channel towards the workItems buffers.
+	// from where the Node processor reads and redistributes the events to their respective pendingEvents buffers.
+	// External events are also funneled through this channel towards the pendingEvents buffers.
 	eventsIn chan *events.EventList
 
-	// During debugging, Events that would normally be inserted in the workItems event buffer
+	// During debugging, Events that would normally be inserted in the pendingEvents event buffer
 	// (and thus inserted in the event loop) are written to this channel instead if it is not nil.
 	// If this channel is nil, those Events are discarded.
 	debugOut chan *events.EventList
@@ -50,13 +50,13 @@ type Node struct {
 
 	// A buffer for storing outstanding events that need to be processed by the node.
 	// It contains a separate sub-buffer for each type of event.
-	workItems eventBuffer
+	pendingEvents eventBuffer
 
 	// Channels for routing work items between modules.
-	// Whenever workItems contains events, those events will be written (by the process() method)
+	// Whenever pendingEvents contains events, those events will be written (by the process() method)
 	// to the corresponding channel in workChans. When processed by the corresponding module,
 	// the result of that processing (also a list of events) will also be written
-	// to the appropriate channel in workChans, from which the process() method moves them to the workItems buffer.
+	// to the appropriate channel in workChans, from which the process() method moves them to the pendingEvents buffer.
 	workChans workChans
 
 	// Used to synchronize the exit of the node's worker go routines.
@@ -122,7 +122,7 @@ func NewNode(
 		modules:     m,
 		interceptor: interceptor,
 
-		workItems:       newEventBuffer(m),
+		pendingEvents:   newEventBuffer(m),
 		workErrNotifier: newWorkErrNotifier(),
 
 		inputPaused:     false,
@@ -182,7 +182,7 @@ func (n *Node) Run(ctx context.Context) error {
 	defer close(n.stopped)
 
 	// Submit the Init event to the modules.
-	if err := n.workItems.AddEvents(createInitEvents(n.modules)); err != nil {
+	if err := n.pendingEvents.Add(createInitEvents(n.modules)); err != nil {
 		n.workErrNotifier.Fail(err)
 		return es.Errorf("failed to add init event: %w", err)
 	}
@@ -258,13 +258,13 @@ func (n *Node) process(ctx context.Context) error { //nolint:gocyclo
 			defer n.statsLock.Unlock()
 
 			newEvents := newEventsVal.Interface().(*events.EventList)
-			if err := n.workItems.AddEvents(newEvents); err != nil {
+			if err := n.pendingEvents.Add(newEvents); err != nil {
 				n.workErrNotifier.Fail(err)
 			}
 
 			// Keep track of the size of the input buffer.
 			// When it exceeds the PauseInputThreshold, pause the input from active modules.
-			if n.workItems.totalEvents > n.Config.PauseInputThreshold {
+			if n.pendingEvents.totalEvents > n.Config.PauseInputThreshold {
 				n.pauseInput()
 			}
 		})
@@ -282,7 +282,7 @@ func (n *Node) process(ctx context.Context) error { //nolint:gocyclo
 		// For each generic event buffer in eventBuffer that contains events to be submitted to its corresponding module,
 		// create a selectCase for writing those events to the module's work channel.
 		n.statsLock.Lock()
-		for moduleID, buffer := range n.workItems.buffers {
+		for moduleID, buffer := range n.pendingEvents.buffers {
 			if buffer.Len() > 0 {
 
 				eventBatch := buffer.Head(n.Config.MaxEventBatchSize)
@@ -306,12 +306,12 @@ func (n *Node) process(ctx context.Context) error { //nolint:gocyclo
 					n.statsLock.Lock()
 					defer n.statsLock.Unlock()
 
-					n.workItems.buffers[mID].RemoveFront(numEvents)
+					n.pendingEvents.buffers[mID].RemoveFront(numEvents)
 
 					// Keep track of the size of the event buffer.
 					// Whenever it drops below the ResumeInputThreshold, resume input.
-					n.workItems.totalEvents -= numEvents
-					if n.workItems.totalEvents <= n.Config.ResumeInputThreshold {
+					n.pendingEvents.totalEvents -= numEvents
+					if n.pendingEvents.totalEvents <= n.Config.ResumeInputThreshold {
 						n.resumeInput()
 					}
 

--- a/node_test.go
+++ b/node_test.go
@@ -136,7 +136,8 @@ func TestNode_Backpressure(t *testing.T) {
 
 	ctx := context.Background()
 
-	nodeConfig := DefaultNodeConfig()
+	nodeConfig := DefaultNodeConfig().WithLogger(logging.ConsoleDebugLogger)
+	nodeConfig.StatsLogInterval = 100 * time.Millisecond
 
 	// Set an input event rate that would fill the node's event buffers in one second in 10 batches.
 	blabberModule := newBlabber(uint64(nodeConfig.PauseInputThreshold/10), 100*time.Millisecond)
@@ -149,7 +150,7 @@ func TestNode_Backpressure(t *testing.T) {
 	// Instantiate node with a fast blabber module and a slow consumer module.
 	n, err := NewNode(
 		"testnode",
-		DefaultNodeConfig(),
+		nodeConfig,
 		map[types.ModuleID]modules.Module{
 			"blabber":  blabberModule,
 			"consumer": consumerModule,

--- a/nodestats.go
+++ b/nodestats.go
@@ -1,0 +1,106 @@
+package mir
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/mir/pkg/logging"
+	t "github.com/filecoin-project/mir/pkg/types"
+	"github.com/filecoin-project/mir/pkg/util/maputil"
+)
+
+// ==============================================================================================================
+// Event dispatching statistics
+// ==============================================================================================================
+
+// eventDispatchStats saves statistical information about the dispatching of events between modules,
+// such the numbers of events dispatched for each module.
+type eventDispatchStats struct {
+	dispatchCounts map[t.ModuleID]int
+	eventCounts    map[t.ModuleID]int
+	numDispatches  int
+	lastDispatch   time.Time
+}
+
+// newDispatchStats returns a new eventDispatchStats object with all counters set to 0
+// and the last dispatch time set to the current time.
+func newDispatchStats(moduleIDs []t.ModuleID) eventDispatchStats {
+	stats := eventDispatchStats{
+		dispatchCounts: make(map[t.ModuleID]int),
+		eventCounts:    make(map[t.ModuleID]int),
+		numDispatches:  0,
+		lastDispatch:   time.Now(),
+	}
+	for _, moduleID := range moduleIDs {
+		stats.dispatchCounts[moduleID] = 0
+		stats.eventCounts[moduleID] = 0
+	}
+	return stats
+}
+
+// AddDispatch registers the dispatching of an event list between two modules to the statistics.
+func (ds *eventDispatchStats) AddDispatch(mID t.ModuleID, numEvents int) {
+	ds.numDispatches++
+	ds.dispatchCounts[mID]++
+	ds.eventCounts[mID] += numEvents
+}
+
+// CombinedStats returns the dispatching statistics combined with information about event buffer occupancy
+// in a format that can directly be passed to the logger.
+// For each module, it includes the number of event lists dispatched to that module (d),
+// the total number of events in those lists (e),
+// and the number of events still buffered at the input of that module (b).
+func (ds *eventDispatchStats) CombinedStats(bufferStats map[t.ModuleID]int) []interface{} {
+	logVals := make([]interface{}, 0, len(ds.eventCounts)+2)
+	totalEventsDispatched := 0
+	totalEventsBuffered := 0
+	for mID, cnt := range ds.dispatchCounts {
+		logVals = append(logVals,
+			fmt.Sprint(mID), fmt.Sprintf("d(%d)-e(%d)-b(%d)", cnt, ds.eventCounts[mID], bufferStats[mID]),
+		)
+		totalEventsDispatched += ds.eventCounts[mID]
+		totalEventsBuffered += bufferStats[mID]
+	}
+	logVals = append(logVals,
+		"numDispatches", ds.numDispatches,
+		"totalEventsDispatched", totalEventsDispatched,
+		"totalEventsBuffered", totalEventsBuffered,
+	)
+	return logVals
+}
+
+// ==============================================================================================================
+// Additional methods of Node that deal with stats.
+// ==============================================================================================================
+
+// monitorStats prints and resets the dispatching statistics every given time interval, until the node is stopped.
+func (n *Node) monitorStats(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+
+Loop:
+	for {
+		select {
+		case <-n.workErrNotifier.ExitC():
+			ticker.Stop()
+			break Loop
+		case <-ticker.C:
+			n.flushStats()
+		}
+	}
+}
+
+func (n *Node) flushStats() {
+	n.statsLock.Lock()
+	defer n.statsLock.Unlock()
+
+	eventBufferStats := n.workItems.Stats()
+	stats := n.dispatchStats.CombinedStats(eventBufferStats)
+
+	if n.inputIsPaused() {
+		n.Config.Logger.Log(logging.LevelDebug, "External event processing paused.", stats...)
+	} else {
+		n.Config.Logger.Log(logging.LevelDebug, "External event processing running.", stats...)
+	}
+
+	n.dispatchStats = newDispatchStats(maputil.GetSortedKeys(n.modules))
+}

--- a/nodestats.go
+++ b/nodestats.go
@@ -54,13 +54,14 @@ func (ds *eventDispatchStats) CombinedStats(bufferStats map[t.ModuleID]int) []in
 	logVals := make([]interface{}, 0, len(ds.eventCounts)+2)
 	totalEventsDispatched := 0
 	totalEventsBuffered := 0
-	for mID, cnt := range ds.dispatchCounts {
+	maputil.IterateSorted(ds.dispatchCounts, func(mID t.ModuleID, cnt int) (cont bool) {
 		logVals = append(logVals,
 			fmt.Sprint(mID), fmt.Sprintf("d(%d)-e(%d)-b(%d)", cnt, ds.eventCounts[mID], bufferStats[mID]),
 		)
 		totalEventsDispatched += ds.eventCounts[mID]
 		totalEventsBuffered += bufferStats[mID]
-	}
+		return true
+	})
 	logVals = append(logVals,
 		"numDispatches", ds.numDispatches,
 		"totalEventsDispatched", totalEventsDispatched,

--- a/nodestats.go
+++ b/nodestats.go
@@ -14,7 +14,7 @@ import (
 // ==============================================================================================================
 
 // eventDispatchStats saves statistical information about the dispatching of events between modules,
-// such the numbers of events dispatched for each module.
+// such as the numbers of events dispatched for each module.
 type eventDispatchStats struct {
 	dispatchCounts map[t.ModuleID]int
 	eventCounts    map[t.ModuleID]int

--- a/nodestats.go
+++ b/nodestats.go
@@ -93,7 +93,7 @@ func (n *Node) flushStats() {
 	n.statsLock.Lock()
 	defer n.statsLock.Unlock()
 
-	eventBufferStats := n.workItems.Stats()
+	eventBufferStats := n.pendingEvents.Stats()
 	stats := n.dispatchStats.CombinedStats(eventBufferStats)
 
 	if n.inputIsPaused() {

--- a/pkg/deploytest/deployment.go
+++ b/pkg/deploytest/deployment.go
@@ -114,6 +114,7 @@ func NewDeployment(conf *TestConfig) (*Deployment, error) {
 
 		// Configure the test replica's node.
 		config := mir.DefaultNodeConfig().WithLogger(logging.Decorate(conf.Logger, fmt.Sprintf("Node %d: ", i)))
+		config.StatsLogInterval = 5 * time.Second
 
 		// Create instance of TestReplica.
 		replicas[i] = &TestReplica{

--- a/pkg/deploytest/helpers.go
+++ b/pkg/deploytest/helpers.go
@@ -30,5 +30,5 @@ func NewLogger(parentLogger logging.Logger) logging.Logger {
 	if parentLogger != nil {
 		return logging.Synchronize(parentLogger)
 	}
-	return logging.Synchronize(logging.ConsoleDebugLogger)
+	return logging.ConsoleDebugLogger // No need to synchronize, the ConsoleDebugLogger is already synchronized.
 }


### PR DESCRIPTION
This is more important than it might seem. When testing performance of a Mir-based system, the system is pushed to the limit, event buffers actually get full and external event processing often needs to be paused. Information on the buffer states and processed events brings a lot of insight.