### PR TITLE
Update libp2p dependency

### DIFF
--- a/pkg/net/libp2p/remoteconnection.go
+++ b/pkg/net/libp2p/remoteconnection.go
@@ -11,7 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-yamux/v3"
+	"github.com/libp2p/go-yamux/v4"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/filecoin-project/mir/pkg/logging"


### PR DESCRIPTION
This was a cause of the networking module very easily dropping messages under load.