### PR TITLE
modified existing functions to return an EventList for the modified interceptor for visualization

### DIFF
--- a/cmd/bench/stats/stat-interceptor.go
+++ b/cmd/bench/stats/stat-interceptor.go
@@ -26,18 +26,14 @@ func NewStatInterceptor(s *LiveStats, txConsumer t.ModuleID) *StatInterceptor {
 	return &StatInterceptor{s, txConsumer}
 }
 
-func (i *StatInterceptor) InterceptWithReturn(events *events.EventList) (*events.EventList, error) {
-	panic("implement me")
-}
-
-func (i *StatInterceptor) Intercept(events *events.EventList) error {
+func (i *StatInterceptor) Intercept(events *events.EventList) (*events.EventList, error) {
 
 	// Avoid nil dereference if Intercept is called on a nil *Recorder and simply do nothing.
 	// This can happen if a pointer type to *Recorder is assigned to a variable with the interface type Interceptor.
 	// Mir would treat that variable as non-nil, thinking there is an interceptor, and call Intercept() on it.
 	// For more explanation, see https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1
 	if i == nil {
-		return nil
+		return events, nil
 	}
 
 	it := events.Iterator()
@@ -66,5 +62,5 @@ func (i *StatInterceptor) Intercept(events *events.EventList) error {
 			}
 		}
 	}
-	return nil
+	return events, nil
 }

--- a/cmd/bench/stats/stat-interceptor.go
+++ b/cmd/bench/stats/stat-interceptor.go
@@ -26,6 +26,10 @@ func NewStatInterceptor(s *LiveStats, txConsumer t.ModuleID) *StatInterceptor {
 	return &StatInterceptor{s, txConsumer}
 }
 
+func (i *StatInterceptor) InterceptWithReturn(events *events.EventList) (*events.EventList, error) {
+	panic("implement me")
+}
+
 func (i *StatInterceptor) Intercept(events *events.EventList) error {
 
 	// Avoid nil dereference if Intercept is called on a nil *Recorder and simply do nothing.

--- a/node.go
+++ b/node.go
@@ -464,18 +464,21 @@ func (n *Node) importEvents(
 // Note: The passed Events should be free of any follow-up Events,
 // as those will be intercepted separately when processed.
 // Make sure to call the Strip method of the EventList before passing it to interceptEvents.
-func (n *Node) interceptEvents(events *events.EventList) {
+func (n *Node) interceptEvents(events *events.EventList) *events.EventList {
 
 	// ATTENTION: n.interceptor is an interface type. If it is assigned the nil value of a concrete type,
 	// this condition will evaluate to true, and Intercept(events) will be called on nil.
 	// The implementation of the concrete type must make sure that calling Intercept even on the nil value
 	// does not cause any problems.
 	// For more explanation, see https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1
+	var err error
 	if n.interceptor != nil {
-		if err := n.interceptor.Intercept(events); err != nil {
+		events, err = n.interceptor.InterceptWithReturn(events)
+		if err != nil {
 			n.workErrNotifier.Fail(err)
 		}
 	}
+	return events
 }
 
 func (n *Node) pauseInput() {

--- a/node.go
+++ b/node.go
@@ -461,6 +461,8 @@ func (n *Node) importEvents(
 
 // If the interceptor module is present, passes events to it. Otherwise, does nothing.
 // If an error occurs passing events to the interceptor, notifies the node by means of the workErrorNotifier.
+// The interceptor has the ability to modify the EventList.
+// The events returned by the interceptor are the events actually delivered to the system's modules
 // Note: The passed Events should be free of any follow-up Events,
 // as those will be intercepted separately when processed.
 // Make sure to call the Strip method of the EventList before passing it to interceptEvents.
@@ -473,7 +475,7 @@ func (n *Node) interceptEvents(events *events.EventList) *events.EventList {
 	// For more explanation, see https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1
 	var err error
 	if n.interceptor != nil {
-		events, err = n.interceptor.InterceptWithReturn(events)
+		events, err = n.interceptor.Intercept(events)
 		if err != nil {
 			n.workErrNotifier.Fail(err)
 		}

--- a/pkg/eventlog/eventwriter.go
+++ b/pkg/eventlog/eventwriter.go
@@ -3,12 +3,13 @@ package eventlog
 import (
 	"compress/gzip"
 
+	"github.com/filecoin-project/mir/pkg/events"
 	"github.com/filecoin-project/mir/pkg/logging"
 	t "github.com/filecoin-project/mir/pkg/types"
 )
 
 type EventWriter interface {
-	Write(record EventRecord) (EventRecord, error)
+	Write(evts *events.EventList, timestamp int64) (*events.EventList, error)
 	Flush() error
 	Close() error
 }

--- a/pkg/eventlog/eventwriter.go
+++ b/pkg/eventlog/eventwriter.go
@@ -8,7 +8,7 @@ import (
 )
 
 type EventWriter interface {
-	Write(record EventRecord) error
+	Write(record EventRecord) (EventRecord, error)
 	Flush() error
 	Close() error
 }

--- a/pkg/eventlog/eventwritergzip.go
+++ b/pkg/eventlog/eventwritergzip.go
@@ -35,10 +35,10 @@ func NewGzipWriter(filename string, compressionLevel int, nodeID t.NodeID, logge
 	}, nil
 }
 
-func (w *gzipWriter) Write(record EventRecord) error {
+func (w *gzipWriter) Write(record EventRecord) (EventRecord, error) {
 	gzWriter, err := gzip.NewWriterLevel(w.dest, w.compressionLevel)
 	if err != nil {
-		return err
+		return record, err
 	}
 	defer func() {
 		if err := gzWriter.Close(); err != nil {
@@ -46,7 +46,7 @@ func (w *gzipWriter) Write(record EventRecord) error {
 		}
 	}()
 
-	return writeRecordedEvent(gzWriter, &recordingpb.Entry{
+	return record, writeRecordedEvent(gzWriter, &recordingpb.Entry{
 		NodeId: w.nodeID.Pb(),
 		Time:   record.Time,
 		Events: record.Events.Slice(),

--- a/pkg/eventlog/eventwritergzip.go
+++ b/pkg/eventlog/eventwritergzip.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/filecoin-project/mir/pkg/events"
 	"github.com/filecoin-project/mir/pkg/logging"
 	"github.com/filecoin-project/mir/pkg/pb/recordingpb"
 	t "github.com/filecoin-project/mir/pkg/types"
@@ -35,10 +36,10 @@ func NewGzipWriter(filename string, compressionLevel int, nodeID t.NodeID, logge
 	}, nil
 }
 
-func (w *gzipWriter) Write(record EventRecord) (EventRecord, error) {
+func (w *gzipWriter) Write(evts *events.EventList, timestamp int64) (*events.EventList, error) {
 	gzWriter, err := gzip.NewWriterLevel(w.dest, w.compressionLevel)
 	if err != nil {
-		return record, err
+		return nil, err
 	}
 	defer func() {
 		if err := gzWriter.Close(); err != nil {
@@ -46,10 +47,10 @@ func (w *gzipWriter) Write(record EventRecord) (EventRecord, error) {
 		}
 	}()
 
-	return record, writeRecordedEvent(gzWriter, &recordingpb.Entry{
+	return evts, writeRecordedEvent(gzWriter, &recordingpb.Entry{
 		NodeId: w.nodeID.Pb(),
-		Time:   record.Time,
-		Events: record.Events.Slice(),
+		Time:   timestamp,
+		Events: evts.Slice(),
 	})
 }
 

--- a/pkg/eventlog/eventwritersqlite.go
+++ b/pkg/eventlog/eventwritersqlite.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/mattn/go-sqlite3" // Driver for the sql database
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/filecoin-project/mir/pkg/events"
 	"github.com/filecoin-project/mir/pkg/logging"
 	t "github.com/filecoin-project/mir/pkg/types"
 )
@@ -43,27 +44,27 @@ func NewSqliteWriter(filename string, nodeID t.NodeID, logger logging.Logger) (E
 	}, nil
 }
 
-func (w sqliteWriter) Write(record EventRecord) (EventRecord, error) {
+func (w sqliteWriter) Write(evts *events.EventList, timestamp int64) (*events.EventList, error) {
 	// For each incoming event
-	iter := record.Events.Iterator()
+	iter := evts.Iterator()
 	for event := iter.Next(); event != nil; event = iter.Next() {
 		jsonData, err := protojson.Marshal(event)
 		if err != nil {
-			return record, err
+			return nil, err
 		}
 
 		_, err = w.db.Exec(
 			insert,
-			record.Time,
+			timestamp,
 			w.nodeID,
 			fmt.Sprintf("%T", event.Type)[len("*eventpb.Event_"):],
 			jsonData,
 		)
 		if err != nil {
-			return record, err
+			return nil, err
 		}
 	}
-	return record, nil
+	return evts, nil
 }
 
 func (w sqliteWriter) Flush() error {

--- a/pkg/eventlog/eventwritersqlite.go
+++ b/pkg/eventlog/eventwritersqlite.go
@@ -43,13 +43,13 @@ func NewSqliteWriter(filename string, nodeID t.NodeID, logger logging.Logger) (E
 	}, nil
 }
 
-func (w sqliteWriter) Write(record EventRecord) error {
+func (w sqliteWriter) Write(record EventRecord) (EventRecord, error) {
 	// For each incoming event
 	iter := record.Events.Iterator()
 	for event := iter.Next(); event != nil; event = iter.Next() {
 		jsonData, err := protojson.Marshal(event)
 		if err != nil {
-			return err
+			return record, err
 		}
 
 		_, err = w.db.Exec(
@@ -60,10 +60,10 @@ func (w sqliteWriter) Write(record EventRecord) error {
 			jsonData,
 		)
 		if err != nil {
-			return err
+			return record, err
 		}
 	}
-	return nil
+	return record, nil
 }
 
 func (w sqliteWriter) Flush() error {

--- a/pkg/eventlog/interceptor.go
+++ b/pkg/eventlog/interceptor.go
@@ -15,4 +15,5 @@ type Interceptor interface {
 	// does not cause any problems.
 	// For more explanation, see https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1
 	Intercept(events *events.EventList) error
+	InterceptWithReturn(events *events.EventList) (*events.EventList, error)
 }

--- a/pkg/eventlog/interceptor.go
+++ b/pkg/eventlog/interceptor.go
@@ -14,6 +14,5 @@ type Interceptor interface {
 	// The implementation of the concrete type must make sure that calling Intercept even on the nil value
 	// does not cause any problems.
 	// For more explanation, see https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1
-	Intercept(events *events.EventList) error
-	InterceptWithReturn(events *events.EventList) (*events.EventList, error)
+	Intercept(events *events.EventList) (*events.EventList, error)
 }

--- a/pkg/eventlog/multiinterceptor.go
+++ b/pkg/eventlog/multiinterceptor.go
@@ -8,6 +8,10 @@ type repeater struct {
 	interceptors []Interceptor
 }
 
+func (r *repeater) InterceptWithReturn(events *events.EventList) (*events.EventList, error) {
+	panic("implement me")
+}
+
 func (r *repeater) Intercept(events *events.EventList) error {
 
 	// Avoid nil dereference if Intercept is called on a nil *Recorder and simply do nothing.

--- a/pkg/eventlog/multiinterceptor.go
+++ b/pkg/eventlog/multiinterceptor.go
@@ -8,26 +8,23 @@ type repeater struct {
 	interceptors []Interceptor
 }
 
-func (r *repeater) InterceptWithReturn(events *events.EventList) (*events.EventList, error) {
-	panic("implement me")
-}
-
-func (r *repeater) Intercept(events *events.EventList) error {
+func (r *repeater) Intercept(events *events.EventList) (*events.EventList, error) {
 
 	// Avoid nil dereference if Intercept is called on a nil *Recorder and simply do nothing.
 	// This can happen if a pointer type to *Recorder is assigned to a variable with the interface type Interceptor.
 	// Mir would treat that variable as non-nil, thinking there is an interceptor, and call Intercept() on it.
 	// For more explanation, see https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1
 	if r == nil {
-		return nil
+		return events, nil
 	}
 
 	for _, i := range r.interceptors {
-		if err := i.Intercept(events); err != nil {
-			return err
+		_, err := i.Intercept(events)
+		if err != nil {
+			return events, err
 		}
 	}
-	return nil
+	return events, nil
 }
 
 func MultiInterceptor(interceptors ...Interceptor) Interceptor {

--- a/pkg/eventlog/multiinterceptor.go
+++ b/pkg/eventlog/multiinterceptor.go
@@ -17,11 +17,11 @@ func (r *repeater) Intercept(events *events.EventList) (*events.EventList, error
 	if r == nil {
 		return events, nil
 	}
-
+	var err error
 	for _, i := range r.interceptors {
-		_, err := i.Intercept(events)
+		events, err = i.Intercept(events)
 		if err != nil {
-			return events, err
+			return nil, err
 		}
 	}
 	return events, nil

--- a/pkg/eventlog/recorder.go
+++ b/pkg/eventlog/recorder.go
@@ -25,25 +25,9 @@ import (
 	t "github.com/filecoin-project/mir/pkg/types"
 )
 
-type EventRecord struct {
+type eventRecord struct {
 	Events *events.EventList
 	Time   int64
-}
-
-func (record *EventRecord) Filter(predicate func(event *eventpb.Event) bool) EventRecord {
-	filtered := &events.EventList{}
-
-	iter := record.Events.Iterator()
-	for event := iter.Next(); event != nil; event = iter.Next() {
-		if predicate(event) {
-			filtered.PushBack(event)
-		}
-	}
-
-	return EventRecord{
-		Events: filtered,
-		Time:   record.Time,
-	}
 }
 
 // Recorder is intended to be used as an implementation of the
@@ -53,14 +37,14 @@ type Recorder struct {
 	nodeID         t.NodeID
 	dest           EventWriter
 	timeSource     func() int64
-	newDests       func(EventRecord) []EventRecord
+	newDests       func(list *events.EventList) []*events.EventList
 	path           string
 	filter         func(event *eventpb.Event) bool
 	newEventWriter func(dest string, nodeID t.NodeID, logger logging.Logger) (EventWriter, error)
 	syncWrite      bool
 
 	logger     logging.Logger
-	eventC     chan EventRecord
+	eventC     chan eventRecord
 	doneC      chan struct{}
 	exitC      chan struct{}
 	fileCount  int
@@ -87,7 +71,7 @@ func NewRecorder(
 		timeSource: func() int64 {
 			return time.Since(startTime).Milliseconds()
 		},
-		eventC:    make(chan EventRecord, DefaultBufferSize),
+		eventC:    make(chan eventRecord, DefaultBufferSize),
 		doneC:     make(chan struct{}),
 		exitC:     make(chan struct{}),
 		fileCount: 1,
@@ -107,7 +91,7 @@ func NewRecorder(
 		case timeSourceOpt:
 			i.timeSource = v
 		case bufferSizeOpt:
-			i.eventC = make(chan EventRecord, v)
+			i.eventC = make(chan eventRecord, v)
 		case fileSplitterOpt:
 			i.newDests = v
 		case eventFilterOpt:
@@ -162,17 +146,12 @@ func (i *Recorder) Intercept(events *events.EventList) error {
 		return nil
 	}
 
-	record := EventRecord{
-		Events: events,
-		Time:   i.timeSource(),
-	}
-
 	// If synchronous writing is enabled, write data and return immediately, without using any channels.
 	if i.syncWrite {
 		i.writerLock.Lock()
 		defer i.writerLock.Unlock()
 		var err error
-		record, err = i.writeEvents(record)
+		_, err = i.writeEvents(events, i.timeSource())
 		if err != nil {
 			return es.Errorf("error writing events: %w", err)
 		}
@@ -184,7 +163,7 @@ func (i *Recorder) Intercept(events *events.EventList) error {
 
 	// If writing is asynchronous, pass the record to the background writing goroutine.
 	select {
-	case i.eventC <- record:
+	case i.eventC <- eventRecord{events, i.timeSource()}:
 		return nil
 	case <-i.exitC:
 		i.exitErrMutex.Lock()
@@ -203,29 +182,26 @@ func (i *Recorder) InterceptWithReturn(events *events.EventList) (*events.EventL
 		return events, nil
 	}
 
-	record := EventRecord{
-		Events: events,
-		Time:   i.timeSource(),
-	}
-
 	// If synchronous writing is enabled, write data and return immediately, without using any channels.
+	// Event modification is only possible here (in synchronous mode).
 	if i.syncWrite {
 		i.writerLock.Lock()
 		defer i.writerLock.Unlock()
-		var err error
-		record, err = i.writeEvents(record)
+		newEvents, err := i.writeEvents(events, i.timeSource())
 		if err != nil {
-			return events, es.Errorf("error writing events: %w", err)
+			return nil, es.Errorf("error writing events: %w", err)
 		}
 		if err := i.dest.Flush(); err != nil {
-			return events, es.Errorf("error flushing written events: %w", err)
+			return nil, es.Errorf("error flushing written events: %w", err)
 		}
-		return events, nil
+		return newEvents, nil
 	}
 
 	// If writing is asynchronous, pass the record to the background writing goroutine.
+	// Note that the recorder will not modify the event list in asynchronous mode, even if the used event writer
+	// returns a modified event list.
 	select {
-	case i.eventC <- record:
+	case i.eventC <- eventRecord{events, i.timeSource()}:
 		return events, nil
 	case <-i.exitC:
 		i.exitErrMutex.Lock()
@@ -278,6 +254,10 @@ func (i *Recorder) run() (exitErr error) {
 		i.logger.Log(logging.LevelInfo, "Intercepted Events written to event log.", "numEvents", cnt, ", path", i.path)
 	}()
 
+	// Keep reading records of intercepted events and pass them to the event writer.
+	// Note that the return value of writeEvents is ignored.
+	// This is because, in asynchronous mode, the interceptor cannot modify the event stream.
+	// All its modifications are thus ignored.
 	for {
 		select {
 		case <-i.doneC:
@@ -285,7 +265,7 @@ func (i *Recorder) run() (exitErr error) {
 				select {
 				case record := <-i.eventC:
 					var err error
-					_, err = i.writeEvents(record)
+					_, err = i.writeEvents(record.Events, record.Time)
 					if err != nil {
 						return es.Errorf("error serializing to stream: %w", err)
 					}
@@ -295,7 +275,7 @@ func (i *Recorder) run() (exitErr error) {
 			}
 		case record := <-i.eventC:
 			var err error
-			_, err = i.writeEvents(record)
+			_, err = i.writeEvents(record.Events, record.Time)
 			if err != nil {
 				return es.Errorf("error serializing to stream: %w", err)
 			}
@@ -304,9 +284,10 @@ func (i *Recorder) run() (exitErr error) {
 	}
 }
 
-func (i *Recorder) writeEvents(record EventRecord) (EventRecord, error) {
-	eventByDests := i.newDests(record)
+func (i *Recorder) writeEvents(evts *events.EventList, timestamp int64) (*events.EventList, error) {
+	eventByDests := i.newDests(evts)
 	count := 0
+	eventsOut := events.EmptyList()
 	for _, rec := range eventByDests {
 		if count > 0 {
 			// newDest required
@@ -316,24 +297,25 @@ func (i *Recorder) writeEvents(record EventRecord) (EventRecord, error) {
 				i.logger,
 			)
 			if err != nil {
-				return record, err
+				return nil, err
 			}
 			err = i.dest.Close()
 			if err != nil {
-				return record, err
+				return nil, err
 			}
 			i.dest = dest
 			i.fileCount++
 		}
 
-		if rec.Events.Len() != 0 {
+		if rec.Len() != 0 {
 			var err error
-			record, err = i.dest.Write(rec.Filter(i.filter))
+			evtsOut, err := i.dest.Write(rec.Filter(i.filter), timestamp)
 			if err != nil {
-				return record, err
+				return nil, err
 			}
+			eventsOut.PushBackList(evtsOut)
 		}
 		count++
 	}
-	return record, nil
+	return eventsOut, nil
 }

--- a/pkg/eventlog/recorderopts.go
+++ b/pkg/eventlog/recorderopts.go
@@ -1,6 +1,7 @@
 package eventlog
 
 import (
+	"github.com/filecoin-project/mir/pkg/events"
 	"github.com/filecoin-project/mir/pkg/logging"
 	"github.com/filecoin-project/mir/pkg/pb/eventpb"
 	t "github.com/filecoin-project/mir/pkg/types"
@@ -36,9 +37,9 @@ func BufferSizeOpt(size int) RecorderOpt {
 
 // TODO: Write documenting comments for the options below.
 
-type fileSplitterOpt func(EventRecord) []EventRecord
+type fileSplitterOpt func(*events.EventList) []*events.EventList
 
-func FileSplitterOpt(splitter func(EventRecord) []EventRecord) RecorderOpt {
+func FileSplitterOpt(splitter func(*events.EventList) []*events.EventList) RecorderOpt {
 	return fileSplitterOpt(splitter)
 }
 

--- a/workers.go
+++ b/workers.go
@@ -72,7 +72,7 @@ func (n *Node) processModuleEvents(
 
 	// Intercept the (stripped of all follow-ups) events that are about to be processed.
 	// This is only for debugging / diagnostic purposes.
-	n.interceptEvents(eventsIn)
+	eventsIn = n.interceptEvents(eventsIn)
 
 	// In Trace mode, log all events.
 	if n.Config.Logger.MinLevel() <= logging.LevelTrace {


### PR DESCRIPTION
Different functions now return an EventList or an EventRecord such that the Events intercepted by the intercepter can also be modified by it.

may want to check my modifications of the implementations of the following to check nothing is broken unintentionally, as I might have overlooked something:
- type Interceptor in pkg/eventlog/interceptor.go 
- and type EventWriter in pkg/eventlog/eventwriter.go
